### PR TITLE
Adding sensors, temperature override service, fixing some stuff, update MHI-AC-Ctrl-core

### DIFF
--- a/MHI-AC-Ctrl-core.cpp
+++ b/MHI-AC-Ctrl-core.cpp
@@ -4,534 +4,548 @@
 #include "MHI-AC-Ctrl-core.h"
 
 uint16_t calc_checksum(byte* frame) {
-  uint16_t checksum = 0;
-  for (int i = 0; i < CBH; i++)
-    checksum += frame[i];
-  return checksum;
+    uint16_t checksum = 0;
+    for (int i = 0; i < CBH; i++)
+        checksum += frame[i];
+    return checksum;
 }
 
 void MHI_AC_Ctrl_Core::reset_old_values() {  // used e.g. when MQTT connection to broker is lost, to re-output data
-  // old status
-  status_power_old = 0xff;
-  status_mode_old = 0xff;
-  status_fan_old = 0xff;
-  status_vanes_old = 0xff;
-  status_troom_old = 0xff;
-  status_tsetpoint_old = 0x00;
-  status_errorcode_old = 0xff;
+    // old status
+    status_power_old = 0xff;
+    status_mode_old = 0xff;
+    status_fan_old = 0xff;
+    status_vanes_old = 0xff;
+    status_troom_old = 0xfe;
+    status_tsetpoint_old = 0x00;
+    status_errorcode_old = 0xff;
 
-  // old operating data
-  op_mode_old = 0xff;
-  op_settemp_old = 0xff;
-  op_return_air_old = 0xff;
-  op_iu_fanspeed_old = 0xff;
-  op_thi_r1_old = 0x00;
-  op_thi_r2_old = 0x00;
-  op_thi_r3_old = 0x00;
-  op_total_iu_run_old = 0;
-  op_outdoor_old = 0xff;
-  op_tho_r1_old = 0x00;
-  op_total_comp_run_old = 0;
-  op_ct_old = 0xff;
-  op_tdsh_old = 0xff;
-  op_protection_no_old = 0xff;
-  op_ou_fanspeed_old = 0xff;
-  op_defrost_old = 0x00;
-  op_comp_old = 0xffff;
-  op_td_old  = 0x00;
-  op_ou_eev1_old = 0xffff;
+    // old operating data
+    op_mode_old = 0xff;
+    op_settemp_old = 0xff;
+    op_return_air_old = 0xff;
+    op_iu_fanspeed_old = 0xff;
+    op_thi_r1_old = 0x00;
+    op_thi_r2_old = 0x00;
+    op_thi_r3_old = 0x00;
+    op_total_iu_run_old = 0;
+    op_outdoor_old = 0xff;
+    op_tho_r1_old = 0x00;
+    op_total_comp_run_old = 0;
+    op_ct_old = 0xff;
+    op_tdsh_old = 0xff;
+    op_protection_no_old = 0xff;
+    op_ou_fanspeed_old = 0xff;
+    op_defrost_old = 0x00;
+    op_comp_old = 0xffff;
+    op_td_old  = 0x00;
+    op_ou_eev1_old = 0xffff;
 }
 
 volatile uint rising_edge_cnt_SCK = 0;
 ICACHE_RAM_ATTR void handleInterrupt_SCK() {
-  rising_edge_cnt_SCK++;
+    rising_edge_cnt_SCK++;
 }
 
 volatile uint rising_edge_cnt_MOSI = 0;
 ICACHE_RAM_ATTR void handleInterrupt_MOSI() {
-  rising_edge_cnt_MOSI++;
+    rising_edge_cnt_MOSI++;
 }
 
 volatile uint rising_edge_cnt_MISO = 0;
 ICACHE_RAM_ATTR void handleInterrupt_MISO() {
-  rising_edge_cnt_MISO++;
+    rising_edge_cnt_MISO++;
 }
 
 void MeasureFrequency(CallbackInterface_Status *m_cbiStatus) {  // measure the frequency on the pins
-  char strtmp[10];
-  pinMode(SCK_PIN, INPUT);
-  pinMode(MOSI_PIN, INPUT);
-  pinMode(MISO_PIN, INPUT);
-  Serial.println(F("Measure frequency for SCK, MOSI and MISO pin"));
-  attachInterrupt(digitalPinToInterrupt(SCK_PIN), handleInterrupt_SCK, RISING);
-  attachInterrupt(digitalPinToInterrupt(MOSI_PIN), handleInterrupt_MOSI, RISING);
-  attachInterrupt(digitalPinToInterrupt(MISO_PIN), handleInterrupt_MISO, RISING);
-  unsigned long starttimeMicros = micros();
-  while (micros() - starttimeMicros < 1000000);
-  detachInterrupt(SCK_PIN);
-  detachInterrupt(MOSI_PIN);
-  detachInterrupt(MISO_PIN);
+    pinMode(SCK_PIN, INPUT);
+    pinMode(MOSI_PIN, INPUT);
+    pinMode(MISO_PIN, INPUT);
+    Serial.println(F("Measure frequency for SCK, MOSI and MISO pin"));
+    attachInterrupt(digitalPinToInterrupt(SCK_PIN), handleInterrupt_SCK, RISING);
+    attachInterrupt(digitalPinToInterrupt(MOSI_PIN), handleInterrupt_MOSI, RISING);
+    attachInterrupt(digitalPinToInterrupt(MISO_PIN), handleInterrupt_MISO, RISING);
+    unsigned long starttimeMicros = micros();
+    while (micros() - starttimeMicros < 1000000);
+    detachInterrupt(SCK_PIN);
+    detachInterrupt(MOSI_PIN);
+    detachInterrupt(MISO_PIN);
 
-  m_cbiStatus->cbiStatusFunction(status_fsck, rising_edge_cnt_SCK);
-  m_cbiStatus->cbiStatusFunction(status_fmosi, rising_edge_cnt_MOSI);
-  m_cbiStatus->cbiStatusFunction(status_fmiso, rising_edge_cnt_MISO);
+    m_cbiStatus->cbiStatusFunction(status_fsck, rising_edge_cnt_SCK);
+    m_cbiStatus->cbiStatusFunction(status_fmosi, rising_edge_cnt_MOSI);
+    m_cbiStatus->cbiStatusFunction(status_fmiso, rising_edge_cnt_MISO);
 
-  Serial.printf_P(PSTR("SCK frequency=%iHz (expected: >3000Hz) "), rising_edge_cnt_SCK);
-  if (rising_edge_cnt_SCK > 3000)
-    Serial.println(F("o.k."));
-  else
-    Serial.println(F("out of range!"));
+    Serial.printf_P(PSTR("SCK frequency=%iHz (expected: >3000Hz) "), rising_edge_cnt_SCK);
+    if (rising_edge_cnt_SCK > 3000)
+        Serial.println(F("o.k."));
+    else
+        Serial.println(F("out of range!"));
 
-  Serial.printf("MOSI frequency=%iHz (expected: <SCK frequency) ", rising_edge_cnt_MOSI);
-  if ((rising_edge_cnt_MOSI > 30) & (rising_edge_cnt_MOSI < rising_edge_cnt_SCK))
-    Serial.println(F("o.k."));
-  else
-    Serial.println(F("out of range!"));
+    Serial.printf("MOSI frequency=%iHz (expected: <SCK frequency) ", rising_edge_cnt_MOSI);
+    if ((rising_edge_cnt_MOSI > 30) & (rising_edge_cnt_MOSI < rising_edge_cnt_SCK))
+        Serial.println(F("o.k."));
+    else
+        Serial.println(F("out of range!"));
 
-  Serial.printf("MISO frequency=%iHz (expected: ~0Hz) ", rising_edge_cnt_MISO);
-  if (rising_edge_cnt_MISO <= 10) {
-    Serial.println(F("o.k."));
-  }
-  else {
-    Serial.println(F("out of range!"));
-    while (1);
-  }
+    Serial.printf("MISO frequency=%iHz (expected: ~0Hz) ", rising_edge_cnt_MISO);
+    if (rising_edge_cnt_MISO <= 10) {
+        Serial.println(F("o.k."));
+    }
+    else {
+        Serial.println(F("out of range!"));
+        while (1);
+    }
 }
 
 void MHI_AC_Ctrl_Core::init() {
-  MeasureFrequency(m_cbiStatus);
-  pinMode(SCK_PIN, INPUT);
-  pinMode(MOSI_PIN, INPUT);
-  pinMode(MISO_PIN, OUTPUT);
-  MHI_AC_Ctrl_Core::reset_old_values();
+    MeasureFrequency(m_cbiStatus);
+    pinMode(SCK_PIN, INPUT);
+    pinMode(MOSI_PIN, INPUT);
+    pinMode(MISO_PIN, OUTPUT);
+    MHI_AC_Ctrl_Core::reset_old_values();
 }
 
 void MHI_AC_Ctrl_Core::set_power(boolean power) {
-  new_Power = 0b10 | power;
+    new_Power = 0b10 | power;
 }
 
 void MHI_AC_Ctrl_Core::set_mode(ACMode mode) {
-  new_Mode = 0b00100000 | mode;
+    new_Mode = 0b00100000 | mode;
 }
 
 void MHI_AC_Ctrl_Core::set_tsetpoint(uint tsetpoint) {
-  new_Tsetpoint = 0b10000000 | (2 * tsetpoint);
+    //new_Tsetpoint = 0b10000000 | (2 * tsetpoint);
+    new_Tsetpoint = 0b10000000 | tsetpoint;
 }
 
 void MHI_AC_Ctrl_Core::set_fan(uint fan) {
-  if (fan == 4) {
-    new_Fan1 = 0b00001010;
-    new_Fan6 = 0b00010000;
-  }
-  else
-    new_Fan1 = 0b00001000 | (fan - 1);
+    if (fan == 4) {
+        new_Fan1 = 0b00001010;
+        new_Fan6 = 0b00010000;
+    }
+    else
+        new_Fan1 = 0b00001000 | (fan - 1);
 }
 
 void MHI_AC_Ctrl_Core::set_vanes(uint vanes) {
-  if (vanes == vanes_swing) {
-    new_Vanes0 = 0b11000000; // enable swing
-  }
-  else {
-    new_Vanes0 = 0b10000000; // disable swing
-    new_Vanes1 = 0b10000000 | ((vanes - 1) << 4);
-  }
+    if (vanes == vanes_swing) {
+        new_Vanes0 = 0b11000000; // enable swing
+    }
+    else {
+        new_Vanes0 = 0b10000000; // disable swing
+        new_Vanes1 = 0b10000000 | ((vanes - 1) << 4);
+    }
 }
 
 void MHI_AC_Ctrl_Core::request_ErrOpData() {
-  request_erropData = true;
+    request_erropData = true;
 }
 
-int MHI_AC_Ctrl_Core::loop(uint max_time_ms) {
-  const byte opdataCnt = sizeof(opdata) / sizeof(byte) / 2;
-  static byte opdataNo = 0;               //
-  int startMillis = millis();             // start time of this loop run
-  byte MOSI_byte;                         // received MOSI byte
-  bool new_datapacket_received = false;   // indicated that a new frame was received
-  static byte erropdataCnt = 0;           // number of expected error operating data
-  static bool doubleframe = false;
-  static byte frame = 0;
-  static byte MOSI_frame[20];
-  //                            sb0   sb1   sb2   db0   db1   db2   db3   db4   db5   db6   db7   db8   db9  db10  db11  db12  db13  db14  chkH  chkL
-  static byte MISO_frame[] = { 0xA9, 0x00, 0x07, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x00, 0x00, 0x00 };
+#ifndef ROOM_TEMP_IU
+void MHI_AC_Ctrl_Core::set_troom(byte troom) {
+    Serial.printf("MHI_AC_Ctrl_Core::set_troom %i\n", troom);
+    new_Troom = troom;
+}
+#endif
 
-  static uint call_counter = 0;           // counts how often this loop was called
-  call_counter++;
-  int SCKMillis = millis();               // time of last SCK low level
-  while (millis() - SCKMillis < 5) { // wait for 5ms stable high signal to detect a frame start
-    if (!digitalRead(SCK_PIN))
-      SCKMillis = millis();
-    if (millis() - startMillis > max_time_ms)
-      return err_msg_timeout;
-  }
+int MHI_AC_Ctrl_Core::loop(int max_time_ms) {
+    const byte opdataCnt = sizeof(opdata) / sizeof(byte) / 2;
+    static byte opdataNo = 0;               //
+    long startMillis = millis();             // start time of this loop run
+    byte MOSI_byte;                         // received MOSI byte
+    bool new_datapacket_received = false;   // indicated that a new frame was received
+    static byte erropdataCnt = 0;           // number of expected error operating data
+    static bool doubleframe = false;
+    static byte frame = 0;
+    static byte MOSI_frame[20];
+    //                            sb0   sb1   sb2   db0   db1   db2   db3   db4   db5   db6   db7   db8   db9  db10  db11  db12  db13  db14  chkH  chkL
+    static byte MISO_frame[] = { 0xA9, 0x00, 0x07, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x0f, 0x00, 0x00, 0x00 };
 
-  // build the next MISO frame
-  if (frame++ >= NoFramesPerPacket) {       // setup MISO frame with each frame packet
-    doubleframe = !doubleframe;             // toggle
-    MISO_frame[DB14] = doubleframe << 2;    // MISO_frame[DB14] bit2 toggels with every frame packet
-    frame = 1;
-    if (doubleframe) {                     // and the other MISO data are updated after two frame packets
-      MISO_frame[DB0] = 0x00;
-      MISO_frame[DB1] = 0x00;
-      MISO_frame[DB2] = 0x00;
-      if (erropdataCnt == 0) {
-        MISO_frame[DB6] = pgm_read_word(opdata + opdataNo);
-        MISO_frame[DB9] = pgm_read_word(opdata + opdataNo) >> 8;
-        opdataNo = (opdataNo + 1) % opdataCnt;
-      }
-      else { // error operating data available
-        MISO_frame[DB6] = 0x80;
-        MISO_frame[DB9] = 0xff;
-        erropdataCnt--;
-      }
+    static uint call_counter = 0;           // counts how often this loop was called
 
-      // set Power, Mode, Tsetpoint, Fan, Vanes
-      MISO_frame[DB0] = new_Power;
-      new_Power = 0;
-
-      MISO_frame[DB0] |= new_Mode;
-      new_Mode = 0;
-
-      MISO_frame[DB2] = new_Tsetpoint;
-      new_Tsetpoint = 0;
-
-      MISO_frame[DB1] = new_Fan1;
-      MISO_frame[DB6] |= new_Fan6;
-      new_Fan1 = 0;
-      new_Fan6 = 0;
-
-      MISO_frame[DB0] |= new_Vanes0;
-      MISO_frame[DB1] |= new_Vanes1;
-      new_Vanes0 = 0;
-      new_Vanes1 = 0;
-
-      if (request_erropData) {
-        MISO_frame[DB6] = 0x80;
-        MISO_frame[DB9] = 0x45;
-        request_erropData = false;
-      }
+    call_counter++;
+    int SCKMillis = millis();               // time of last SCK low level
+    while (millis() - SCKMillis < 5) {      // wait for 5ms stable high signal to detect a frame start
+        if (!digitalRead(SCK_PIN))
+            SCKMillis = millis();
+        if (millis() - startMillis > max_time_ms)
+            return err_msg_timeout_SCK_low;       // SCK stuck@ low error detection
     }
-  }
+    // build the next MISO frame
+    if (frame++ >= NoFramesPerPacket) {       // setup MISO frame with each frame packet
+        doubleframe = !doubleframe;             // toggle
+        MISO_frame[DB14] = doubleframe << 2;    // MISO_frame[DB14] bit2 toggels with every frame packet
+        frame = 1;
+        if (doubleframe) {                     // and the other MISO data are updated after two frame packets
+            MISO_frame[DB0] = 0x00;
+            MISO_frame[DB1] = 0x00;
+            MISO_frame[DB2] = 0x00;
+            if (erropdataCnt == 0) {
+                MISO_frame[DB6] = pgm_read_word(opdata + opdataNo);
+                MISO_frame[DB9] = pgm_read_word(opdata + opdataNo) >> 8;
+                opdataNo = (opdataNo + 1) % opdataCnt;
+            }
+            else { // error operating data available
+                MISO_frame[DB6] = 0x80;
+                MISO_frame[DB9] = 0xff;
+                erropdataCnt--;
+            }
 
-  uint16_t checksum = calc_checksum(MISO_frame);
-  MISO_frame[CBH] = highByte(checksum);
-  MISO_frame[CBL] = lowByte(checksum);
+            // set Power, Mode, Tsetpoint, Fan, Vanes
+            MISO_frame[DB0] = new_Power;
+            new_Power = 0;
 
-  //Serial.println();
-  //Serial.print(F("MISO:"));
-  // read/write MOSI/MISO frame
-  for (uint8_t byte_cnt = 0; byte_cnt < sizeof(MOSI_frame); byte_cnt++) { // read and write a data packet of 20 bytes
-    //Serial.printf("x%02x ", MISO_frame[byte_cnt]);
-    MOSI_byte = 0;
-    byte bit_mask = 1;
-    for (uint8_t bit_cnt = 0; bit_cnt < 8; bit_cnt++) { // read and write 1 byte
-      while (digitalRead(SCK_PIN)) {} // wait for falling edge
-      if ((MISO_frame[byte_cnt] & bit_mask) > 0)
-        digitalWrite(MISO_PIN, 1);
-      else
-        digitalWrite(MISO_PIN, 0);
-      while (!digitalRead(SCK_PIN)) {} // wait for rising edge
-      if (digitalRead(MOSI_PIN))
-        MOSI_byte += bit_mask;
-      bit_mask = bit_mask << 1;
-    }
-    if (MOSI_frame[byte_cnt] != MOSI_byte) {
-      new_datapacket_received = true;
-      MOSI_frame[byte_cnt] = MOSI_byte;
-    }
-  }
+            MISO_frame[DB0] |= new_Mode;
+            new_Mode = 0;
 
-  checksum = calc_checksum(MOSI_frame);
-  if (((MOSI_frame[SB0] & 0xfe) != 0x6c) | (MOSI_frame[SB1] != 0x80) | (MOSI_frame[SB2] != 0x04))
-    return err_msg_invalid_signature;
-  if ((MOSI_frame[CBH] << 8 | MOSI_frame[CBL]) != checksum)
-    return err_msg_invalid_checksum;
+            MISO_frame[DB2] = new_Tsetpoint;
+            new_Tsetpoint = 0;
 
-  if (new_datapacket_received) {
-    // evaluate status
-    if ((MOSI_frame[DB0] & 0x1c) != status_mode_old) { // Mode
-      status_mode_old = MOSI_frame[DB0] & 0x1c;
-      m_cbiStatus->cbiStatusFunction(status_mode, status_mode_old);
+            MISO_frame[DB1] = new_Fan1;
+            MISO_frame[DB6] |= new_Fan6;
+            new_Fan1 = 0;
+            new_Fan6 = 0;
+
+            MISO_frame[DB0] |= new_Vanes0;
+            MISO_frame[DB1] |= new_Vanes1;
+            new_Vanes0 = 0;
+            new_Vanes1 = 0;
+
+            if (request_erropData) {
+                MISO_frame[DB6] = 0x80;
+                MISO_frame[DB9] = 0x45;
+                request_erropData = false;
+            }
+        }
     }
 
-    if ((MOSI_frame[DB0] & 0x01) != status_power_old) { // Power
-      status_power_old = MOSI_frame[DB0] & 0x01;
-      m_cbiStatus->cbiStatusFunction(status_power, status_power_old);
+#ifndef ROOM_TEMP_IU
+    MISO_frame[DB3] = new_Troom;
+#endif
+    uint16_t checksum = calc_checksum(MISO_frame);
+    MISO_frame[CBH] = highByte(checksum);
+    MISO_frame[CBL] = lowByte(checksum);
+
+    //Serial.println();
+    //Serial.print(F("MISO:"));
+    // read/write MOSI/MISO frame
+    for (uint8_t byte_cnt = 0; byte_cnt < sizeof(MOSI_frame); byte_cnt++) { // read and write a data packet of 20 bytes
+        //Serial.printf("x%02x ", MISO_frame[byte_cnt]);
+        MOSI_byte = 0;
+        byte bit_mask = 1;
+        for (uint8_t bit_cnt = 0; bit_cnt < 8; bit_cnt++) { // read and write 1 byte
+            SCKMillis = millis();
+            while (digitalRead(SCK_PIN)) { // wait for falling edge
+                if (millis() - startMillis > max_time_ms)
+                    return err_msg_timeout_SCK_high;       // SCK stuck@ high error detection
+            }
+            if ((MISO_frame[byte_cnt] & bit_mask) > 0)
+                digitalWrite(MISO_PIN, 1);
+            else
+                digitalWrite(MISO_PIN, 0);
+            while (!digitalRead(SCK_PIN)) {} // wait for rising edge
+            if (digitalRead(MOSI_PIN))
+                MOSI_byte += bit_mask;
+            bit_mask = bit_mask << 1;
+        }
+        if (MOSI_frame[byte_cnt] != MOSI_byte) {
+            new_datapacket_received = true;
+            MOSI_frame[byte_cnt] = MOSI_byte;
+        }
     }
 
-    uint fantmp;
-    if ((MOSI_frame[DB6] & 0x40) != 0) // Fan status
-      fantmp = 3;
-    else
-      fantmp = (MOSI_frame[DB1] & 0x03);
-    if (fantmp != status_fan_old) {
-      status_fan_old = fantmp;
-      m_cbiStatus->cbiStatusFunction(status_fan, status_fan_old);
-    }
+    checksum = calc_checksum(MOSI_frame);
+    if (((MOSI_frame[SB0] & 0xfe) != 0x6c) | (MOSI_frame[SB1] != 0x80) | (MOSI_frame[SB2] != 0x04))
+        return err_msg_invalid_signature;
+    if ((MOSI_frame[CBH] << 8 | MOSI_frame[CBL]) != checksum)
+        return err_msg_invalid_checksum;
 
-    // Only updated when Vanes command via wired RC
-    uint vanestmp = (MOSI_frame[DB0] & 0xc0) + ((MOSI_frame[DB1] & 0xB0) >> 4);
-    if (vanestmp != status_vanes_old) {
-      if ((vanestmp & 0x88) == 0) // last vanes update was via IR-RC, so status is not known
-        m_cbiStatus->cbiStatusFunction(status_vanes, vanes_unknown);
-      else if ((vanestmp & 0x40) != 0) // Vanes status swing
-        m_cbiStatus->cbiStatusFunction(status_vanes, vanes_swing);
-      else {
-        m_cbiStatus->cbiStatusFunction(status_vanes, (vanestmp & 0x03) + 1);
-      }
-      status_vanes_old = vanestmp;
-    }
+    if (new_datapacket_received) {
+        // evaluate status
+        if ((MOSI_frame[DB0] & 0x1c) != status_mode_old) { // Mode
+            status_mode_old = MOSI_frame[DB0] & 0x1c;
+            m_cbiStatus->cbiStatusFunction(status_mode, status_mode_old);
+        }
 
-    int8_t troom_diff = MOSI_frame[DB3] - status_troom_old; // avoid using other functions inside the brackets of abs, see https://www.arduino.cc/reference/en/language/functions/math/abs/
-    if (abs(troom_diff) > 1) { // Room temperature delta > 0.25°C
-      status_troom_old = MOSI_frame[DB3];
-      m_cbiStatus->cbiStatusFunction(status_troom, status_troom_old);
-    }
+        if ((MOSI_frame[DB0] & 0x01) != status_power_old) { // Power
+            status_power_old = MOSI_frame[DB0] & 0x01;
+            m_cbiStatus->cbiStatusFunction(status_power, status_power_old);
+        }
 
-    if (MOSI_frame[DB2] != status_tsetpoint_old) { // Temperature setpoint
-      status_tsetpoint_old = MOSI_frame[DB2];
-      m_cbiStatus->cbiStatusFunction(status_tsetpoint, (status_tsetpoint_old & 0x7f) >> 1);
-    }
+        uint fantmp;
+        if ((MOSI_frame[DB6] & 0x40) != 0) // Fan status
+            fantmp = 3;
+        else
+            fantmp = (MOSI_frame[DB1] & 0x03);
+        if (fantmp != status_fan_old) {
+            status_fan_old = fantmp;
+            m_cbiStatus->cbiStatusFunction(status_fan, status_fan_old);
+        }
 
-    if (MOSI_frame[DB4] != status_errorcode_old) { // error code
-      status_errorcode_old = MOSI_frame[DB4];
-      m_cbiStatus->cbiStatusFunction(status_errorcode, status_errorcode_old);
-    }
+        // Only updated when Vanes command via wired RC
+        uint vanestmp = (MOSI_frame[DB0] & 0xc0) + ((MOSI_frame[DB1] & 0xB0) >> 4);
+        if (vanestmp != status_vanes_old) {
+            if ((vanestmp & 0x88) == 0) // last vanes update was via IR-RC, so status is not known
+                m_cbiStatus->cbiStatusFunction(status_vanes, vanes_unknown);
+            else if ((vanestmp & 0x40) != 0) // Vanes status swing
+                m_cbiStatus->cbiStatusFunction(status_vanes, vanes_swing);
+            else {
+                m_cbiStatus->cbiStatusFunction(status_vanes, (vanestmp & 0x03) + 1);
+            }
+            status_vanes_old = vanestmp;
+        }
 
-    // Evaluate Operating Data and Error Operating Data
-    bool MOSI_type_opdata = (MOSI_frame[DB10] & 0x30) == 0x10;
+        int8_t troom_diff = MOSI_frame[DB3] - status_troom_old; // avoid using other functions inside the brackets of abs, see https://www.arduino.cc/reference/en/language/functions/math/abs/
+        if (abs(troom_diff) > 1) { // Room temperature delta > 0.25°C
+            status_troom_old = MOSI_frame[DB3];
+            m_cbiStatus->cbiStatusFunction(status_troom, status_troom_old);
+        }
 
-    switch (MOSI_frame[DB9]) {
-      case 0x02:
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 1 MODE
-          if (MOSI_type_opdata) {
-            if ((MOSI_frame[DB10] != op_mode_old)) {
-              op_mode_old = MOSI_frame[DB10];
-              m_cbiStatus->cbiStatusFunction(opdata_mode, (op_mode_old & 0x0f) << 2);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_mode, (MOSI_frame[DB10] & 0x0f) << 2);
+        if (MOSI_frame[DB2] != status_tsetpoint_old) { // Temperature setpoint
+            status_tsetpoint_old = MOSI_frame[DB2];
+            m_cbiStatus->cbiStatusFunction(status_tsetpoint, status_tsetpoint_old);
         }
-        break;
-      case 0x05:
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 2 SET-TEMP
-          if (MOSI_frame[DB10] == 0x13) {
-            if (MOSI_frame[DB11] != op_settemp_old) {
-              op_settemp_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_tsetpoint, op_settemp_old >> 1);
-            }
-          }
-          else if (MOSI_frame[DB10] == 0x33)
-            m_cbiStatus->cbiStatusFunction(erropdata_tsetpoint, MOSI_frame[DB11] >> 1);
+
+        if (MOSI_frame[DB4] != status_errorcode_old) { // error code
+            status_errorcode_old = MOSI_frame[DB4];
+            m_cbiStatus->cbiStatusFunction(status_errorcode, status_errorcode_old);
         }
-        break;
-      case 0x81:                              // 5 THI-R1 or 6 THI-R2
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 5 THI-R1
-          if ((MOSI_frame[DB10] & 0x30) == 0x20) {
-            if (MOSI_frame[DB11] != op_thi_r1_old) {
-              op_thi_r1_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_thi_r1, op_thi_r1_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_thi_r1, MOSI_frame[DB11]);
+
+        // Evaluate Operating Data and Error Operating Data
+        bool MOSI_type_opdata = (MOSI_frame[DB10] & 0x30) == 0x10;
+
+        switch (MOSI_frame[DB9]) {
+            case 0x02:
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 1 MODE
+                    if (MOSI_type_opdata) {
+                        if ((MOSI_frame[DB10] != op_mode_old)) {
+                            op_mode_old = MOSI_frame[DB10];
+                            m_cbiStatus->cbiStatusFunction(opdata_mode, (op_mode_old & 0x0f) << 2);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_mode, (MOSI_frame[DB10] & 0x0f) << 2);
+                }
+                break;
+            case 0x05:
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 2 SET-TEMP
+                    if (MOSI_frame[DB10] == 0x13) {
+                        if (MOSI_frame[DB11] != op_settemp_old) {
+                            op_settemp_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_tsetpoint, op_settemp_old);
+                        }
+                    }
+                    else if (MOSI_frame[DB10] == 0x33)
+                        m_cbiStatus->cbiStatusFunction(erropdata_tsetpoint, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x81:                              // 5 THI-R1 or 6 THI-R2
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 5 THI-R1
+                    if ((MOSI_frame[DB10] & 0x30) == 0x20) {
+                        if (MOSI_frame[DB11] != op_thi_r1_old) {
+                            op_thi_r1_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_thi_r1, op_thi_r1_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_thi_r1, MOSI_frame[DB11]);
+                }
+                else {                                // 6 THI-R2
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_thi_r2_old) {
+                            op_thi_r2_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_thi_r2, op_thi_r2_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_thi_r2, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x87:
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 7 THI-R3
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_thi_r3_old) {
+                            op_thi_r3_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_thi_r3, op_thi_r3_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_thi_r3, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x80:                              // 3 RETURN-AIR or 21 OUTDOOR
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 3 RETURN-AIR
+                    if ((MOSI_frame[DB10] & 0x30) == 0x20) {           // operating Data
+                        if (MOSI_frame[DB11] != op_return_air_old) {
+                            op_return_air_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_return_air, op_return_air_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_return_air, MOSI_frame[DB11]);
+                }
+                else {                                // 21 OUTDOOR
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_outdoor_old) {
+                            op_outdoor_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_outdoor, op_outdoor_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_outdoor, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x1f:                              // 8 IU-FANSPEED or 34 OU-FANSPEED
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 8 IU-FANSPEED
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB10] != op_iu_fanspeed_old) {
+                            op_iu_fanspeed_old = MOSI_frame[DB10];
+                            m_cbiStatus->cbiStatusFunction(opdata_iu_fanspeed, op_iu_fanspeed_old & 0x0f);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_iu_fanspeed, MOSI_frame[DB10] & 0x0f);
+                }
+                else {                                // 34 OU-FANSPEED
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB10] != op_ou_fanspeed_old) {
+                            op_ou_fanspeed_old = MOSI_frame[DB10];
+                            m_cbiStatus->cbiStatusFunction(opdata_ou_fanspeed, op_ou_fanspeed_old & 0x0f);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_ou_fanspeed, MOSI_frame[DB10] & 0x0f);
+                }
+                break;
+            case 0x1e:                              // 12 TOTAL-IU-RUN or 37 TOTAL-COMP-RUN
+                if ((MOSI_frame[DB6] & 0x80) != 0) {  // 12 TOTAL-IU-RUN
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_total_iu_run_old) {
+                            op_total_iu_run_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_total_iu_run, op_total_iu_run_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_total_iu_run, MOSI_frame[DB11]);
+                }
+                else {                                // 37 TOTAL-COMP-RUN
+                    if (MOSI_frame[DB10] == 0x11) {
+                        if (MOSI_frame[DB11] != op_total_comp_run_old) {
+                            op_total_comp_run_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_total_comp_run, op_total_comp_run_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_total_comp_run, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x82:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 22 ThO-R1
+                    if (MOSI_type_opdata) {    // operating data
+                        if (MOSI_frame[DB11] != op_tho_r1_old) {
+                            op_tho_r1_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_tho_r1, op_tho_r1_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_tho_r1, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x11:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 24 COMP
+                    if (MOSI_type_opdata) {
+                        if ((MOSI_frame[DB10] << 8 | MOSI_frame[DB11]) != op_comp_old) {
+                            op_comp_old = MOSI_frame[DB10] << 8 | MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_comp, op_comp_old & 0x0fff);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_comp, (MOSI_frame[DB10] << 8 | MOSI_frame[DB11]) & 0x0fff);
+                }
+                break;
+            case 0x85:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 27 Td
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_td_old) {
+                            op_td_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_td, op_td_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_td, MOSI_frame[DB11]);
+                }
+                break;
+            case 0x90:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 29 CT
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_ct_old) {
+                            op_ct_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_ct, op_ct_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_ct, MOSI_frame[DB11]);
+                }
+                break;
+            case 0xb1:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 32 TDSH
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_tdsh_old) {
+                            op_tdsh_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_tdsh, op_tdsh_old / 2);
+                        }
+                    }
+                }
+                break;
+            case 0x7c:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 33 PROTECTION-No
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB11] != op_protection_no_old) {
+                            op_protection_no_old = MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_protection_no, op_protection_no_old);
+                        }
+                    }
+                }
+                break;
+            case 0x0c:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 36 DEFROST
+                    if (MOSI_type_opdata) {
+                        if (MOSI_frame[DB10] != op_defrost_old) {
+                            op_defrost_old = MOSI_frame[DB10];
+                            m_cbiStatus->cbiStatusFunction(opdata_defrost, op_defrost_old & 0b1);
+                        }
+                    }
+                }
+                break;
+            case 0x13:
+                if ((MOSI_frame[DB6] & 0x80) == 0) {  // 38 OU-EEV
+                    if (MOSI_type_opdata) {
+                        if ((MOSI_frame[DB12] << 8 | MOSI_frame[DB11]) != op_ou_eev1_old) {
+                            op_ou_eev1_old = MOSI_frame[DB12] << 8 | MOSI_frame[DB11];
+                            m_cbiStatus->cbiStatusFunction(opdata_ou_eev1, op_ou_eev1_old);
+                        }
+                    }
+                    else
+                        m_cbiStatus->cbiStatusFunction(erropdata_ou_eev1, MOSI_frame[DB12] << 8 | MOSI_frame[DB11]);
+                }
+                break;
+            case 0x45: // last error number or count of following error operating data
+                if ((MOSI_frame[DB6] & 0x80) != 0) {
+                    if (MOSI_frame[DB10] == 0x11) {     // last error number
+                        m_cbiStatus->cbiStatusFunction(erropdata_errorcode, MOSI_frame[DB11]);
+                    }
+                    else if (MOSI_frame[DB10] == 0x12) { // count of following error operating data
+                        erropdataCnt = MOSI_frame[DB11] + 4;
+                    }
+                }
+                break;
+            case 0x00:  // dummy
+                break;
+            case 0xff:  // default
+                break;
+            default:    // unknown operating data
+                m_cbiStatus->cbiStatusFunction(opdata_unknwon, MOSI_frame[DB10] << 8 | MOSI_frame[DB9]);
         }
-        else {                                // 6 THI-R2
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_thi_r2_old) {
-              op_thi_r2_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_thi_r2, op_thi_r2_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_thi_r2, MOSI_frame[DB11]);
-        }
-        break;
-      case 0x87:
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 7 THI-R3
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_thi_r3_old) {
-              op_thi_r3_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_thi_r3, op_thi_r3_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_thi_r3, MOSI_frame[DB11]);
-        }
-        break;
-      case 0x80:                              // 3 RETURN-AIR or 21 OUTDOOR
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 3 RETURN-AIR
-          if ((MOSI_frame[DB10] & 0x30) == 0x20) {           // operating Data
-            if (MOSI_frame[DB11] != op_return_air_old) {
-              op_return_air_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_return_air, op_return_air_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_return_air, MOSI_frame[DB11]);
-        }
-        else {                                // 21 OUTDOOR
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_outdoor_old) {
-              op_outdoor_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_outdoor, op_outdoor_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_outdoor, MOSI_frame[DB11]);
-        }
-        break;
-      case 0x1f:                              // 8 IU-FANSPEED or 34 OU-FANSPEED
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 8 IU-FANSPEED
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB10] != op_iu_fanspeed_old) {
-              op_iu_fanspeed_old = MOSI_frame[DB10];
-              m_cbiStatus->cbiStatusFunction(opdata_iu_fanspeed, op_iu_fanspeed_old & 0x0f);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_iu_fanspeed, MOSI_frame[DB10] & 0x0f);
-        }
-        else {                                // 34 OU-FANSPEED
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB10] != op_ou_fanspeed_old) {
-              op_ou_fanspeed_old = MOSI_frame[DB10];
-              m_cbiStatus->cbiStatusFunction(opdata_ou_fanspeed, op_ou_fanspeed_old & 0x0f);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_ou_fanspeed, MOSI_frame[DB10] & 0x0f);
-        }
-        break;
-      case 0x1e:                              // 12 TOTAL-IU-RUN or 37 TOTAL-COMP-RUN
-        if ((MOSI_frame[DB6] & 0x80) != 0) {  // 12 TOTAL-IU-RUN
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_total_iu_run_old) {
-              op_total_iu_run_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_total_iu_run, op_total_iu_run_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_total_iu_run, MOSI_frame[DB11]);
-        }
-        else {                                // 37 TOTAL-COMP-RUN
-          if (MOSI_frame[DB10] == 0x11) {
-            if (MOSI_frame[DB11] != op_total_comp_run_old) {
-              op_total_comp_run_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_total_comp_run, op_total_comp_run_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_total_comp_run, MOSI_frame[DB11]);
-        }
-        break;
-      case 0x82:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 22 ThO-R1
-          if (MOSI_type_opdata) {    // operating data
-            if (MOSI_frame[DB11] != op_tho_r1_old) {
-              op_tho_r1_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_tho_r1, op_tho_r1_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_tho_r1, MOSI_frame[DB11]);
-        }
-        break;
-      case 0x11:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 24 COMP
-          if (MOSI_type_opdata) {
-            if ((MOSI_frame[DB10] << 8 | MOSI_frame[DB11]) != op_comp_old) {
-              op_comp_old = MOSI_frame[DB10] << 8 | MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_comp, op_comp_old & 0x0fff);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_comp, (MOSI_frame[DB10] << 8 | MOSI_frame[DB11]) & 0x0fff);
-        }
-        break;
-      case 0x85:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 27 Td
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_td_old) {
-              op_td_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_td, op_td_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_td, MOSI_frame[DB11]);
-        }
-        break;
-      case 0x90:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 29 CT
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_ct_old) {
-              op_ct_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_ct, op_ct_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_ct, MOSI_frame[DB11]);
-        }
-        break;
-      case 0xb1:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 32 TDSH
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_tdsh_old) {
-              op_tdsh_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_tdsh, op_tdsh_old / 2);
-            }
-          }
-        }
-        break;
-      case 0x7c:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 33 PROTECTION-No
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB11] != op_protection_no_old) {
-              op_protection_no_old = MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_protection_no, op_protection_no_old);
-            }
-          }
-        }
-        break;
-      case 0x0c:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 36 DEFROST
-          if (MOSI_type_opdata) {
-            if (MOSI_frame[DB10] != op_defrost_old) {
-              op_defrost_old = MOSI_frame[DB10];
-              m_cbiStatus->cbiStatusFunction(opdata_defrost, op_defrost_old & 0b1);
-            }
-          }
-        }
-        break;
-      case 0x13:
-        if ((MOSI_frame[DB6] & 0x80) == 0) {  // 38 OU-EEV
-          if (MOSI_type_opdata) {
-            if ((MOSI_frame[DB12] << 8 | MOSI_frame[DB11]) != op_ou_eev1_old) {
-              op_ou_eev1_old = MOSI_frame[DB12] << 8 | MOSI_frame[DB11];
-              m_cbiStatus->cbiStatusFunction(opdata_ou_eev1, op_ou_eev1_old);
-            }
-          }
-          else
-            m_cbiStatus->cbiStatusFunction(erropdata_ou_eev1, MOSI_frame[DB12] << 8 | MOSI_frame[DB11]);
-        }
-        break;
-      case 0x45: // last error number or count of following error operating data
-        if ((MOSI_frame[DB6] & 0x80) != 0) {
-          if (MOSI_frame[DB10] == 0x11) {     // last error number
-            m_cbiStatus->cbiStatusFunction(erropdata_errorcode, MOSI_frame[DB11]);
-          }
-          else if (MOSI_frame[DB10] == 0x12) { // count of following error operating data
-            erropdataCnt = MOSI_frame[DB11] + 4;
-          }
-        }
-        break;
-      case 0x00:  // dummy
-        break;
-      case 0xff:  // default
-        break;
-      default:    // unknown operating data
-        m_cbiStatus->cbiStatusFunction(opdata_unknwon, MOSI_frame[DB10] << 8 | MOSI_frame[DB9]);
     }
-  }
-  return call_counter;
+    return call_counter;
 }

--- a/MHI-AC-Ctrl-core.h
+++ b/MHI-AC-Ctrl-core.h
@@ -5,26 +5,26 @@
 
 // comment out the data you are not interested, but at least leave the last dummy row
 const byte opdata[][2] PROGMEM = {
-  { 0xc0, 0x02},  //  1 "MODE"
-  { 0xc0, 0x05},  //  2 "SET-TEMP" [°C]
-  { 0xc0, 0x80},  //  3 "RETURN-AIR" [°C]
-  { 0xc0, 0x81},  //  5 "THI-R1" [°C]
-  { 0x40, 0x81},  //  6 "THI-R2" [°C]
-  { 0xc0, 0x87},  //  7 "THI-R3" [°C]
-  { 0xc0, 0x1f},  //  8 "IU-FANSPEED"
-  { 0xc0, 0x1e},  // 12 "TOTAL-IU-RUN" [h]
-  { 0x40, 0x80},  // 21 "OUTDOOR" [°C]
-  { 0x40, 0x82},  // 22 "THO-R1" [°C]
-  { 0x40, 0x11},  // 24 "COMP" [Hz]
-  { 0x40, 0x85},  // 27 "TD" [A]
-  { 0x40, 0x90},  // 29 "CT" [A]
-  { 0x40, 0xb1},  // 32 "TDSH" [°C]
-  { 0x40, 0x7c},  // 33 "PROTECTION-No"
-  { 0x40, 0x1f},  // 34 "OU-FANSPEED"
-  { 0x40, 0x0c},  // 36 "DEFROST"
-  { 0x40, 0x1e},  // 37 "TOTAL-COMP-RUN" [h]
-  { 0x40, 0x13},  // 38 "OU-EEV" [Puls]
-  { 0x00, 0x00},  // dummy
+        { 0xc0, 0x02},  //  1 "MODE"
+        { 0xc0, 0x05},  //  2 "SET-TEMP" [°C]
+        { 0xc0, 0x80},  //  3 "RETURN-AIR" [°C]
+        { 0xc0, 0x81},  //  5 "THI-R1" [°C]
+        { 0x40, 0x81},  //  6 "THI-R2" [°C]
+        { 0xc0, 0x87},  //  7 "THI-R3" [°C]
+        { 0xc0, 0x1f},  //  8 "IU-FANSPEED"
+        { 0xc0, 0x1e},  // 12 "TOTAL-IU-RUN" [h]
+        { 0x40, 0x80},  // 21 "OUTDOOR" [°C]
+        { 0x40, 0x82},  // 22 "THO-R1" [°C]
+        { 0x40, 0x11},  // 24 "COMP" [Hz]
+        { 0x40, 0x85},  // 27 "TD" [A]
+        { 0x40, 0x90},  // 29 "CT" [A]
+        { 0x40, 0xb1},  // 32 "TDSH" [°C]
+        { 0x40, 0x7c},  // 33 "PROTECTION-No"
+        { 0x40, 0x1f},  // 34 "OU-FANSPEED"
+        { 0x40, 0x0c},  // 36 "DEFROST"
+        { 0x40, 0x1e},  // 37 "TOTAL-COMP-RUN" [h]
+        { 0x40, 0x13},  // 38 "OU-EEV" [Puls]
+        { 0x00, 0x00},  // dummy
 };
 
 #define NoFramesPerPacket 20                 // number of frames/packet, must be an even number
@@ -54,41 +54,41 @@ const byte opdata[][2] PROGMEM = {
 #define CBL DB14 + 2
 
 enum ErrMsg {   // Error message enum
-  err_msg_valid_frame = 0, err_msg_invalid_signature = -1, err_msg_invalid_checksum = -2, err_msg_timeout = -3
+    err_msg_valid_frame = 0, err_msg_invalid_signature = -1, err_msg_invalid_checksum = -2, err_msg_timeout_SCK_low = -3, err_msg_timeout_SCK_high = -4
 };
 
 enum ACType {   // Type enum
-  type_status = 0x40, type_opdata = 0x80, type_erropdata = 0xc0
+    type_status = 0x40, type_opdata = 0x80, type_erropdata = 0xc0
 };
 
 enum ACStatus { // Status enum
-  status_rssi = type_status, status_connected, status_cmd, status_tds1820, status_fsck, status_fmosi, status_fmiso, status_power, status_mode, status_fan, status_vanes, status_troom, status_tsetpoint, status_errorcode,
-  opdata_mode = type_opdata, opdata_tsetpoint, opdata_return_air, opdata_outdoor, opdata_tho_r1, opdata_iu_fanspeed, opdata_thi_r1, opdata_thi_r2, opdata_thi_r3,
-  opdata_ou_fanspeed, opdata_total_iu_run, opdata_total_comp_run, opdata_comp, opdata_ct, opdata_td,
-  opdata_tdsh, opdata_protection_no, opdata_defrost, opdata_ou_eev1, opdata_unknwon,
-  erropdata_mode = type_erropdata, erropdata_tsetpoint, erropdata_return_air, erropdata_thi_r1, erropdata_thi_r2, erropdata_thi_r3,
-  erropdata_iu_fanspeed, erropdata_total_iu_run, erropdata_outdoor, erropdata_tho_r1, erropdata_comp, erropdata_td, erropdata_ct, erropdata_ou_fanspeed,
-  erropdata_total_comp_run, erropdata_ou_eev1, erropdata_errorcode
+    status_rssi = type_status, status_mqtt_lost, status_wifi_lost, status_connected, status_cmd, status_tds1820, status_fsck, status_fmosi, status_fmiso, status_power, status_mode, status_fan, status_vanes, status_troom, status_tsetpoint, status_errorcode,
+    opdata_mode = type_opdata, opdata_tsetpoint, opdata_return_air, opdata_outdoor, opdata_tho_r1, opdata_iu_fanspeed, opdata_thi_r1, opdata_thi_r2, opdata_thi_r3,
+    opdata_ou_fanspeed, opdata_total_iu_run, opdata_total_comp_run, opdata_comp, opdata_ct, opdata_td,
+    opdata_tdsh, opdata_protection_no, opdata_defrost, opdata_ou_eev1, opdata_unknwon,
+    erropdata_mode = type_erropdata, erropdata_tsetpoint, erropdata_return_air, erropdata_thi_r1, erropdata_thi_r2, erropdata_thi_r3,
+    erropdata_iu_fanspeed, erropdata_total_iu_run, erropdata_outdoor, erropdata_tho_r1, erropdata_comp, erropdata_td, erropdata_ct, erropdata_ou_fanspeed,
+    erropdata_total_comp_run, erropdata_ou_eev1, erropdata_errorcode
 };
 
 enum ACPower {  // Power enum
-  power_off = 0, power_on = 1
+    power_off = 0, power_on = 1
 };
 
 enum ACMode {   // Mode enum
-  mode_auto = 0b00000000, mode_dry = 0b00000100, mode_cool = 0b00001000, mode_fan = 0b00001100, mode_heat = 0b00010000
+    mode_auto = 0b00000000, mode_dry = 0b00000100, mode_cool = 0b00001000, mode_fan = 0b00001100, mode_heat = 0b00010000
 };
 
 enum ACVanes {  // Vanes enum
-  vanes_1 = 1, vanes_2 = 2, vanes_3 = 3, vanes_4 = 4, vanes_unknown = 0, vanes_swing = 5
+    vanes_1 = 1, vanes_2 = 2, vanes_3 = 3, vanes_4 = 4, vanes_unknown = 0, vanes_swing = 5
 };
 
 class CallbackInterface_Status {
-  public: virtual void cbiStatusFunction(ACStatus status, int value) = 0;
+public: virtual void cbiStatusFunction(ACStatus status, int value) = 0;
 };
 
 class MHI_AC_Ctrl_Core {
-  private:
+private:
     // old status
     byte status_power_old;
     byte status_mode_old;
@@ -128,23 +128,25 @@ class MHI_AC_Ctrl_Core {
     byte new_Vanes0 = 0;
     byte new_Vanes1 = 0;
     bool request_erropData = false;
+    byte new_Troom = 0xff;
 
     CallbackInterface_Status *m_cbiStatus;
 
-  public:
+public:
     void MHIAcCtrlStatus(CallbackInterface_Status *cb) {
-      m_cbiStatus = cb;
+        m_cbiStatus = cb;
     };
 
     void init();                          // initialization called once after boot
     void reset_old_values();              // resets the 'old' variables ensuring that all status information are resend
-    int loop(uint max_time_ms);           // receive / transmit a frame of 20 bytes
+    int loop(int max_time_ms);            // receive / transmit a frame of 20 bytes
     void set_power(boolean power);        // power on/off the AC
     void set_mode(ACMode mode);           // change AC mode (e.g. heat, dry, cool etc.)
     void set_tsetpoint(uint tsetpoint);   // set the target temperature of the AC)
     void set_fan(uint fan);               // set the requested fan speed
     void set_vanes(uint vanes);           // set the vanes horizontal position (or swing)
     void request_ErrOpData();             // request that the AC provides the error data
+    void set_troom(byte temperature);     // set the room temperature used by AC
 };
 
 #endif

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -3,7 +3,7 @@ substitutions:
   devicename: "MHI-AC-Ctrl" # Unique device name in HA (sensor names will be prefixed by this name)
 
 esphome:
-  name: mhi-ac-ctrl # ESPHome device name, should be unique
+  name: lr_mhi_ac_ctrl
   platform: ESP8266
   board: d1_mini
   platformio_options:

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -39,6 +39,13 @@ sensor:
     sensors:
       - name: "Error code"
       - name: "Outdoor temperature"
+      - name: "Return air temperature"
+      - name: "Outdoor unit fan speed"
+      - name: "Indoor unit fan speed"
+      - name: "Current"
+      - name: "Compressor frequency"
+      - name: "Indoor unit run time"
+      - name: "Compressor run time"
 
 binary_sensor:
   - platform: custom

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -1,7 +1,13 @@
+substitutions:
+  deviceid: "mhi_ac_ctrl" # Unique device ID in HA
+  devicename: "MHI-AC-Ctrl" # Unique device name in HA (sensor names will be prefixed by this name)
+
 esphome:
-  name: lr_mhi_ac_ctrl
+  name: mhi-ac-ctrl # ESPHome device name, should be unique
   platform: ESP8266
   board: d1_mini
+  platformio_options:
+    board_build.f_cpu: 160000000L # Run CPU at 160Mhz to fix mhi_ac_ctrl_core.loop error: -2
   includes:
     - mhi_ac_ctrl.h
     - MHI-AC-Ctrl-core.h
@@ -11,12 +17,18 @@ wifi:
   ssid: "**SSID**"
   password: "**PASSWORD**"
 
+  ap:
+    ssid: ${devicename}
+
 logger:
   level: DEBUG
   baud_rate: 0
 
-api:
-  reboot_timeout: 0s
+globals:
+  - id: room_temp_api_timeout
+    type: int
+    restore_value: no
+    initial_value: '120'
 
 ota:
 
@@ -28,29 +40,55 @@ climate:
       return {mhi_ac_ctrl};
 
     climates:
-      - name: "MHI-AC-Ctrl"
-        id: mhi_ac_ctrl
+      - name: "${devicename}"
+        id: ${deviceid}
+
+api:
+  reboot_timeout: 0s
+  services:
+    - service: set_api_room_temperature
+      variables:
+        value: float
+      then:
+        - lambda: |-
+            return ((MhiAcCtrl*)id(${deviceid}))->set_room_temperature(value);
 
 sensor:
+  - platform: uptime
+    name: ${devicename} Uptime
+  - platform: wifi_signal
+    name: ${devicename} WiFi Signal
+    update_interval: 60s
   - platform: custom
     lambda: |-
-      return ((MhiAcCtrl*)mhi_ac_ctrl)->get_sensors();
+      return ((MhiAcCtrl*)id(${deviceid}))->get_sensors();
 
     sensors:
-      - name: "Error code"
-      - name: "Outdoor temperature"
-      - name: "Return air temperature"
-      - name: "Outdoor unit fan speed"
-      - name: "Indoor unit fan speed"
-      - name: "Current"
-      - name: "Compressor frequency"
-      - name: "Indoor unit run time"
-      - name: "Compressor run time"
+      - name: ${devicename} error code
+      - name: ${devicename} outdoor temperature
+      - name: ${devicename} return air temperature
+      - name: ${devicename} outdoor unit fan speed
+      - name: ${devicename} indoor unit fan speed
+      - name: ${devicename} current power
+      - name: ${devicename} compressor frequency
+      - name: ${devicename} indoor unit total run time
+      - name: ${devicename} compressor total run time
 
 binary_sensor:
   - platform: custom
     lambda: |-
-      return ((MhiAcCtrl*)mhi_ac_ctrl)->get_binary_sensors();
+      return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
 
     binary_sensors:
-      - name: "Defrost"
+      - name: ${devicename} defrost
+
+text_sensor:
+  - platform: version
+    name: ${devicename} ESPHome Version
+  - platform: wifi_info
+    ip_address:
+      name: ${devicename} IP
+    ssid:
+      name: ${devicename} SSID
+    bssid:
+      name: ${devicename} BSSID

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -1,13 +1,16 @@
 substitutions:
-  deviceid: "mhi_ac_ctrl" # Unique device ID in HA
-  devicename: "MHI-AC-Ctrl" # Unique device name in HA (sensor names will be prefixed by this name)
+  # Unique device ID in HA
+  deviceid: "mhi_ac_ctrl"
+  # Unique device name in HA (sensor names will be prefixed by this name)
+  devicename: "MHI-AC-Ctrl"
 
 esphome:
   name: lr_mhi_ac_ctrl
   platform: ESP8266
   board: d1_mini
   platformio_options:
-    board_build.f_cpu: 160000000L # Run CPU at 160Mhz to fix mhi_ac_ctrl_core.loop error: -2
+    # Run CPU at 160Mhz to fix mhi_ac_ctrl_core.loop error: -2
+    board_build.f_cpu: 160000000L
   includes:
     - mhi_ac_ctrl.h
     - MHI-AC-Ctrl-core.h
@@ -46,6 +49,8 @@ climate:
 api:
   reboot_timeout: 0s
   services:
+    # Call the set_api_room_temperature service from HA to override the room temperature
+    # If a new value has not been received after room_temp_api_timeout seconds, it will fall back to internal sensor
     - service: set_api_room_temperature
       variables:
         value: float
@@ -63,6 +68,8 @@ sensor:
     lambda: |-
       return ((MhiAcCtrl*)id(${deviceid}))->get_sensors();
 
+    # Sensor names in HA, you can change these if you want
+    # Don't delete them or change their position in the list
     sensors:
       - name: ${devicename} error code
       - name: ${devicename} outdoor temperature

--- a/mhi_ac_ctrl.h
+++ b/mhi_ac_ctrl.h
@@ -40,19 +40,21 @@ public:
 
         indoor_unit_fan_speed_.set_icon("mdi:fan");
 
-        current_.set_icon("mdi:current-ac");
-        current_.set_unit_of_measurement("A");
-        current_.set_accuracy_decimals(2);
-
         compressor_frequency_.set_icon("mdi:sine-wave");
         compressor_frequency_.set_unit_of_measurement("Hz");
         compressor_frequency_.set_accuracy_decimals(1);
 
-        indoor_unit_run_time_.set_icon("mdi:clock");
-        indoor_unit_run_time_.set_unit_of_measurement("h");
+        indoor_unit_total_run_time_.set_icon("mdi:clock");
+        indoor_unit_total_run_time_.set_unit_of_measurement("h");
 
-        compressor_run_time_.set_icon("mdi:clock");
-        compressor_run_time_.set_unit_of_measurement("h");
+        compressor_total_run_time_.set_icon("mdi:clock");
+        compressor_total_run_time_.set_unit_of_measurement("h");
+
+        current_power_.set_icon("mdi:current-ac");
+        current_power_.set_unit_of_measurement("A");
+        current_power_.set_accuracy_decimals(2);
+
+        defrost_.set_icon("mdi:snowflake-melt");
 
         mhi_ac_ctrl_core.MHIAcCtrlStatus(this);
         mhi_ac_ctrl_core.init();
@@ -81,15 +83,15 @@ public:
         Serial.printf_P(PSTR("status=%i value=%i\n"), status, value);
         switch (status) {
         case status_fsck:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_FSCK), strtmp);
             break;
         case status_fmosi:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_FMOSI), strtmp);
             break;
         case status_fmiso:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_FMISO), strtmp);
             break;
         case status_power:
@@ -164,6 +166,7 @@ public:
                 this->swing_mode = climate::CLIMATE_SWING_BOTH;
                 break;
             default:
+                break;
                 // itoa(value, strtmp, 10);
                 // output_P(status, PSTR(TOPIC_VANES), strtmp);
             }
@@ -220,7 +223,7 @@ public:
         case erropdata_total_iu_run:
             // itoa(value * 100, strtmp, 10);
             // output_P(status, PSTR(TOPIC_TOTAL_IU_RUN), strtmp);
-            indoor_unit_run_time_.publish_state(value * 100);
+            indoor_unit_total_run_time_.publish_state(value * 100);
             break;
         case erropdata_outdoor:
         case opdata_outdoor:
@@ -252,7 +255,7 @@ public:
         case erropdata_ct:
             // dtostrf(value * 14 / 51.0f, 0, 2, strtmp);
             // output_P(status, PSTR(TOPIC_CT), strtmp);
-            current_.publish_state(value * 14 / 51.0f);
+            current_power_.publish_state(value * 14 / 51.0f);
             break;
         case opdata_tdsh:
             // itoa(value, strtmp, 10); // formula for calculation not known
@@ -266,7 +269,7 @@ public:
         case erropdata_ou_fanspeed:
             // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_OU_FANSPEED), strtmp);
-            indoor_unit_fan_speed_.publish_state(value);
+            outdoor_unit_fan_speed_.publish_state(value);
             break;
         case opdata_defrost:
             // if (value)
@@ -279,7 +282,7 @@ public:
         case erropdata_total_comp_run:
             // itoa(value * 100, strtmp, 10);
             // output_P(status, PSTR(TOPIC_TOTAL_COMP_RUN), strtmp);
-            compressor_run_time_.publish_state(value * 100);
+            compressor_total_run_time_.publish_state(value * 100);
             break;
         case opdata_ou_eev1:
         case erropdata_ou_eev1:
@@ -302,10 +305,10 @@ public:
             &return_air_temperature_,
             &outdoor_unit_fan_speed_,
             &indoor_unit_fan_speed_,
-            &current_,
+            &current_power_,
             &compressor_frequency_,
-            &indoor_unit_run_time_,
-            &compressor_run_time_
+            &indoor_unit_total_run_time_,
+            &compressor_total_run_time_
         };
     }
 
@@ -432,9 +435,9 @@ protected:
     Sensor return_air_temperature_ { "Return air temperature" };
     Sensor outdoor_unit_fan_speed_ { "Outdoor unit fan speed" };
     Sensor indoor_unit_fan_speed_ { "Indoor unit fan speed" };
-    Sensor current_ { "Current" };
     Sensor compressor_frequency_ { "Compressor frequency" };
-    Sensor indoor_unit_run_time_ { "Indoor unit run time" };
-    Sensor compressor_run_time_ { "Compressor run time" };
+    Sensor indoor_unit_total_run_time_ { "Indoor unit run time" };
+    Sensor compressor_total_run_time_ { "Compressor run time" };
+    Sensor current_power_ { "Current power" };
     BinarySensor defrost_ { "Defrost" };
 };

--- a/mhi_ac_ctrl.h
+++ b/mhi_ac_ctrl.h
@@ -30,7 +30,29 @@ public:
 
         outdoor_temperature_.set_icon("mdi:thermometer");
         outdoor_temperature_.set_unit_of_measurement("°C");
-        outdoor_temperature_.set_accuracy_decimals(1);
+        outdoor_temperature_.set_accuracy_decimals(2);
+
+        return_air_temperature_.set_icon("mdi:thermometer");
+        return_air_temperature_.set_unit_of_measurement("°C");
+        return_air_temperature_.set_accuracy_decimals(2);
+
+        outdoor_unit_fan_speed_.set_icon("mdi:fan");
+
+        indoor_unit_fan_speed_.set_icon("mdi:fan");
+
+        current_.set_icon("mdi:current-ac");
+        current_.set_unit_of_measurement("A");
+        current_.set_accuracy_decimals(2);
+
+        compressor_frequency_.set_icon("mdi:sine-wave");
+        compressor_frequency_.set_unit_of_measurement("Hz");
+        compressor_frequency_.set_accuracy_decimals(1);
+
+        indoor_unit_run_time_.set_icon("mdi:clock");
+        indoor_unit_run_time_.set_unit_of_measurement("h");
+
+        compressor_run_time_.set_icon("mdi:clock");
+        compressor_run_time_.set_unit_of_measurement("h");
 
         mhi_ac_ctrl_core.MHIAcCtrlStatus(this);
         mhi_ac_ctrl_core.init();
@@ -142,13 +164,13 @@ public:
                 this->swing_mode = climate::CLIMATE_SWING_BOTH;
                 break;
             default:
-                itoa(value, strtmp, 10);
+                // itoa(value, strtmp, 10);
                 // output_P(status, PSTR(TOPIC_VANES), strtmp);
             }
             this->publish_state();
             break;
         case status_troom:
-            dtostrf((value - 61) / 4.0, 0, 2, strtmp);
+            // dtostrf((value - 61) / 4.0, 0, 2, strtmp);
             // output_P(status, PSTR(TOPIC_TROOM), strtmp);
             this->current_temperature = (value - 61) / 4.0;
             this->publish_state();
@@ -156,89 +178,95 @@ public:
         case status_tsetpoint:
         case opdata_tsetpoint:
         case erropdata_tsetpoint:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_TSETPOINT), strtmp);
             this->target_temperature = value;
             this->publish_state();
             break;
         case status_errorcode:
         case erropdata_errorcode:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_ERRORCODE), strtmp);
             error_code_.publish_state(value);
             break;
         case opdata_return_air:
         case erropdata_return_air:
-            dtostrf(value * 0.25f - 15, 0, 2, strtmp);
+            // dtostrf(value * 0.25f - 15, 0, 2, strtmp);
             // output_P(status, PSTR(TOPIC_RETURNAIR), strtmp);
+            return_air_temperature_.publish_state(value * 0.25f - 15);
             break;
         case opdata_thi_r1:
         case erropdata_thi_r1:
-            itoa(0.327f * value - 11.4f, strtmp, 10); // only rough approximation
+            // itoa(0.327f * value - 11.4f, strtmp, 10); // only rough approximation
             // output_P(status, PSTR(TOPIC_THI_R1), strtmp);
             break;
         case opdata_thi_r2:
         case erropdata_thi_r2:
-            itoa(0.327f * value - 11.4f, strtmp, 10); // formula for calculation not known
+            // itoa(0.327f * value - 11.4f, strtmp, 10); // formula for calculation not known
             // output_P(status, PSTR(TOPIC_THI_R2), strtmp);
             break;
         case opdata_thi_r3:
         case erropdata_thi_r3:
-            itoa(0.327f * value - 11.4f, strtmp, 10); // only rough approximation
+            // itoa(0.327f * value - 11.4f, strtmp, 10); // only rough approximation
             // output_P(status, PSTR(TOPIC_THI_R3), strtmp);
             break;
         case opdata_iu_fanspeed:
         case erropdata_iu_fanspeed:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_IU_FANSPEED), strtmp);
+            indoor_unit_fan_speed_.publish_state(value);
             break;
         case opdata_total_iu_run:
         case erropdata_total_iu_run:
-            itoa(value * 100, strtmp, 10);
+            // itoa(value * 100, strtmp, 10);
             // output_P(status, PSTR(TOPIC_TOTAL_IU_RUN), strtmp);
+            indoor_unit_run_time_.publish_state(value * 100);
             break;
         case erropdata_outdoor:
         case opdata_outdoor:
-            dtostrf((value - 94) * 0.25f, 0, 2, strtmp);
+            // dtostrf((value - 94) * 0.25f, 0, 2, strtmp);
             // output_P(status, PSTR(TOPIC_OUTDOOR), strtmp);
             outdoor_temperature_.publish_state((value - 94) * 0.25f);
             break;
         case opdata_tho_r1:
         case erropdata_tho_r1:
-            itoa(0.327f * value - 11.4f, strtmp, 10); // formula for calculation not known
+            // itoa(0.327f * value - 11.4f, strtmp, 10); // formula for calculation not known
             // output_P(status, PSTR(TOPIC_THO_R1), strtmp);
             break;
         case opdata_comp:
         case erropdata_comp:
-            dtostrf(
-                highByte(value) * 25.6f + 0.1f * lowByte(value), 0, 2, strtmp); // to be confirmed
+            // dtostrf(
+            //    highByte(value) * 25.6f + 0.1f * lowByte(value), 0, 2, strtmp); // to be confirmed
             // output_P(status, PSTR(TOPIC_COMP), strtmp);
+            compressor_frequency_.publish_state(highByte(value) * 25.6f + 0.1f * lowByte(value));
             break;
         case erropdata_td:
         case opdata_td:
-            if (value < 0x12)
-                strcpy(strtmp, "<=30");
-            else
-                itoa(value / 2 + 32, strtmp, 10);
+            // if (value < 0x12)
+            //    strcpy(strtmp, "<=30");
+            // else
+             //   itoa(value / 2 + 32, strtmp, 10);
             // output_P(status, PSTR(TOPIC_TD), strtmp);
             break;
         case opdata_ct:
         case erropdata_ct:
-            dtostrf(value * 14 / 51.0f, 0, 2, strtmp);
+            // dtostrf(value * 14 / 51.0f, 0, 2, strtmp);
             // output_P(status, PSTR(TOPIC_CT), strtmp);
+            current_.publish_state(value * 14 / 51.0f);
             break;
         case opdata_tdsh:
-            itoa(value, strtmp, 10); // formula for calculation not known
+            // itoa(value, strtmp, 10); // formula for calculation not known
             // output_P(status, PSTR(TOPIC_TDSH), strtmp);
             break;
         case opdata_protection_no:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_PROTECTION_NO), strtmp);
             break;
         case opdata_ou_fanspeed:
         case erropdata_ou_fanspeed:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_OU_FANSPEED), strtmp);
+            indoor_unit_fan_speed_.publish_state(value);
             break;
         case opdata_defrost:
             // if (value)
@@ -249,12 +277,13 @@ public:
             break;
         case opdata_total_comp_run:
         case erropdata_total_comp_run:
-            itoa(value * 100, strtmp, 10);
+            // itoa(value * 100, strtmp, 10);
             // output_P(status, PSTR(TOPIC_TOTAL_COMP_RUN), strtmp);
+            compressor_run_time_.publish_state(value * 100);
             break;
         case opdata_ou_eev1:
         case erropdata_ou_eev1:
-            itoa(value, strtmp, 10);
+            // itoa(value, strtmp, 10);
             // output_P(status, PSTR(TOPIC_OU_EEV1), strtmp);
             break;
         case status_rssi:
@@ -267,7 +296,17 @@ public:
     }
 
     std::vector<Sensor *> get_sensors() {
-        return { &error_code_, &outdoor_temperature_ };
+        return {
+            &error_code_,
+            &outdoor_temperature_,
+            &return_air_temperature_,
+            &outdoor_unit_fan_speed_,
+            &indoor_unit_fan_speed_,
+            &current_,
+            &compressor_frequency_,
+            &indoor_unit_run_time_,
+            &compressor_run_time_
+        };
     }
 
     std::vector<BinarySensor *> get_binary_sensors() {
@@ -390,5 +429,12 @@ protected:
 
     Sensor error_code_ { "Error code" };
     Sensor outdoor_temperature_ { "Outdoor temperature" };
+    Sensor return_air_temperature_ { "Return air temperature" };
+    Sensor outdoor_unit_fan_speed_ { "Outdoor unit fan speed" };
+    Sensor indoor_unit_fan_speed_ { "Indoor unit fan speed" };
+    Sensor current_ { "Current" };
+    Sensor compressor_frequency_ { "Compressor frequency" };
+    Sensor indoor_unit_run_time_ { "Indoor unit run time" };
+    Sensor compressor_run_time_ { "Compressor run time" };
     BinarySensor defrost_ { "Defrost" };
 };

--- a/mhi_ac_ctrl.h
+++ b/mhi_ac_ctrl.h
@@ -296,6 +296,8 @@ public:
         case status_rssi:
         case status_connected:
         case status_cmd:
+        case status_mqtt_lost:
+        case status_wifi_lost:
         case status_tds1820:
         case opdata_unknwon:
             break;

--- a/mhi_ac_ctrl.h
+++ b/mhi_ac_ctrl.h
@@ -62,9 +62,9 @@ public:
 
     void loop() override
     {
-       int ret = mhi_ac_ctrl_core.loop(100);
-       if (ret < 0)
-           Serial.printf_P(PSTR("mhi_ac_ctrl_core.loop error: %i\n"), ret);
+        int ret = mhi_ac_ctrl_core.loop(100);
+        if (ret < 0)
+            ESP_LOGW("mhi_ac_ctrl", "mhi_ac_ctrl_core.loop error: %i", ret);
     }
 
     void dump_config() override
@@ -80,7 +80,7 @@ public:
     {
         char strtmp[10];
         static int mode_tmp = 0xff;
-        Serial.printf_P(PSTR("status=%i value=%i\n"), status, value);
+        ESP_LOGD("mhi_ac_ctrl", "status=%i value=%i", status, value);
         switch (status) {
         case status_fsck:
             // itoa(value, strtmp, 10);


### PR DESCRIPTION
Hello!

First off, thanks for your work on this implementation of MHI-AC-Ctrl in ESP Home!

I have made some additions/changes I'd like to contribute with this pull request;

- Upgrade MHI-AC-Ctrl core files to latest version
- Fix temperature setpoint calculations that changed in latest version
- Change mode HEAT_COOL to AUTO, properly process mode OFF
- Add room temperature override feature exposed through API
- Change the min/max temperature setpoints to match the original MHI-AC-Ctrl
- Raise CPU frequency to 160Mhz to fix SPI timing errors causing invalid checksum errors
- Updated YAML with all newest cool stuff and made it a bit more 'multi-unit'-friendly

If anyone wants to test, you can try out this pull request; it should in theory work and not blow up your house, but of course no guarantees ;-). Let me know if there are any issues!