### PR TITLE
HomeAssistant frontend changes

### DIFF
--- a/mhi_ac_ctrl.h
+++ b/mhi_ac_ctrl.h
@@ -128,7 +128,7 @@ public:
                 //    output_P(status, PSTR(TOPIC_MODE), PSTR(PAYLOAD_MODE_STOP));
                 //    break;
                 if (status != erropdata_mode && this->power_ > 0) {
-                    this->mode = climate::CLIMATE_MODE_AUTO;
+                    this->mode = climate::CLIMATE_MODE_HEAT_COOL;
                 } else {
                     this->mode = climate::CLIMATE_MODE_OFF;
                 }
@@ -365,7 +365,7 @@ protected:
             case climate::CLIMATE_MODE_FAN_ONLY:
                 mode_ = mode_fan;
                 break;
-            case climate::CLIMATE_MODE_AUTO:
+            case climate::CLIMATE_MODE_HEAT_COOL:
             default:
                 mode_ = mode_auto;
                 break;
@@ -430,9 +430,8 @@ protected:
     {
         auto traits = climate::ClimateTraits();
         traits.set_supports_current_temperature(true);
-        traits.set_supported_modes({ CLIMATE_MODE_OFF, CLIMATE_MODE_AUTO, CLIMATE_MODE_COOL, CLIMATE_MODE_HEAT, CLIMATE_MODE_DRY, CLIMATE_MODE_FAN_ONLY });
+        traits.set_supported_modes({ CLIMATE_MODE_OFF, CLIMATE_MODE_HEAT_COOL, CLIMATE_MODE_COOL, CLIMATE_MODE_HEAT, CLIMATE_MODE_DRY, CLIMATE_MODE_FAN_ONLY });
         traits.set_supports_two_point_target_temperature(false);
-        traits.set_supported_presets({ CLIMATE_PRESET_NONE });
         traits.set_visual_min_temperature(this->minimum_temperature_);
         traits.set_visual_max_temperature(this->maximum_temperature_);
         traits.set_visual_temperature_step(this->temperature_step_);


### PR DESCRIPTION
- change CLIMATE_MODE_AUTO to CLIMATE_MODE_HEAT_COOL, this changes the icon in the climate entity to arrows without the calendar as the AUTO mode in the unit does not actually have time or date based logic. Only automatic heat or cool logic, thus CLIMATE_MODE_HEAT_COOL.
- removed traits.set_supported_presets({ CLIMATE_PRESET_NONE }); cleanup because the unit has no presets. This removes the preset dropdown from the climate entity.