### PR TITLE
Cleanup config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Has now 5 different fan modes but I'm not sure if the auto mode works proper, ke
 
 # Changelog:
 
+**v2.1** (2024-03)
+ - Breaking change: Cleaned up conf files
+ - Add restart button
+ - Update Home Assistant naming convention
+ - Enable energy dashboard usage 
+
 **v2.0** (2024-01)
  - Based on absalom-muc v2.8 (September 2023)
  - Breaking change in YAML configuration (need to set frame_size in globals)

--- a/conf/large_framesize.yaml
+++ b/conf/large_framesize.yaml
@@ -26,7 +26,7 @@ binary_sensor:
       return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
 
     binary_sensors:
-      - name: ${devicename} defrost
+      - name: Defrost
 
 sensor:
   - platform: custom
@@ -116,7 +116,7 @@ text_sensor:
       return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
 
     text_sensors:
-      - name: ${devicename} compressor protection status
+      - name: Compressor protection status
 
 select:
   - platform: template

--- a/conf/large_framesize.yaml
+++ b/conf/large_framesize.yaml
@@ -3,18 +3,32 @@ globals:
   - id: room_temp_api_timeout
     type: int
     restore_value: no
-    initial_value: '120'
+    initial_value: "120"
   - id: frame_size
     type: byte
     restore_value: no
-    initial_value: '33' # 20 for legacy, 33 for new
+    initial_value: "33" # 20 for legacy, 33 for new
+
+climate:
+  - platform: custom
+    lambda: |-
+      auto mhi_ac_ctrl = new MhiAcCtrl();
+      App.register_component(mhi_ac_ctrl);
+      return {mhi_ac_ctrl};
+
+    climates:
+      - name: "${devicename}"
+        id: ${deviceid}
+
+binary_sensor:
+  - platform: custom
+    lambda: |-
+      return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
+
+    binary_sensors:
+      - name: ${devicename} defrost
 
 sensor:
-  - platform: uptime
-    name: ${devicename} Uptime
-  - platform: wifi_signal
-    name: ${devicename} WiFi Signal
-    update_interval: 60s
   - platform: custom
     lambda: |-
       return ((MhiAcCtrl*)id(${deviceid}))->get_sensors();
@@ -95,6 +109,14 @@ sensor:
                   ESP_LOGD("main", "received 3DAuto off from AC");
                   id(fan_control_3Dauto).publish_state(false);
                 }
+
+text_sensor:
+  - platform: custom
+    lambda: |-
+      return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
+
+    text_sensors:
+      - name: ${devicename} compressor protection status
 
 select:
   - platform: template

--- a/conf/large_framesize.yaml
+++ b/conf/large_framesize.yaml
@@ -1,4 +1,4 @@
-# Version 2.0
+# Version 2.1
 globals:
   - id: room_temp_api_timeout
     type: int

--- a/conf/legacy_framesize.yaml
+++ b/conf/legacy_framesize.yaml
@@ -3,18 +3,32 @@ globals:
   - id: room_temp_api_timeout
     type: int
     restore_value: no
-    initial_value: '120'
+    initial_value: "120"
   - id: frame_size
     type: byte
     restore_value: no
-    initial_value: '20' # 20 for legacy, 33 for new
+    initial_value: "20" # 20 for legacy, 33 for new
+
+climate:
+  - platform: custom
+    lambda: |-
+      auto mhi_ac_ctrl = new MhiAcCtrl();
+      App.register_component(mhi_ac_ctrl);
+      return {mhi_ac_ctrl};
+
+    climates:
+      - name: "${devicename}"
+        id: ${deviceid}
+
+binary_sensor:
+  - platform: custom
+    lambda: |-
+      return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
+
+    binary_sensors:
+      - name: ${devicename} defrost
 
 sensor:
-  - platform: uptime
-    name: ${devicename} Uptime
-  - platform: wifi_signal
-    name: ${devicename} WiFi Signal
-    update_interval: 60s
   - platform: custom
     lambda: |-
       return ((MhiAcCtrl*)id(${deviceid}))->get_sensors();
@@ -58,6 +72,14 @@ sensor:
       - name: ${devicename} Outdoor unit discharge pipe
       - name: ${devicename} Outdoor unit discharge pipe super heat
       - name: ${devicename} Protection error state
+
+text_sensor:
+  - platform: custom
+    lambda: |-
+      return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
+
+    text_sensors:
+      - name: ${devicename} compressor protection status
 
 select:
   - platform: template

--- a/conf/legacy_framesize.yaml
+++ b/conf/legacy_framesize.yaml
@@ -26,7 +26,7 @@ binary_sensor:
       return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
 
     binary_sensors:
-      - name: ${devicename} defrost
+      - name: Defrost
 
 sensor:
   - platform: custom
@@ -79,7 +79,7 @@ text_sensor:
       return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
 
     text_sensors:
-      - name: ${devicename} compressor protection status
+      - name: Compressor protection status
 
 select:
   - platform: template

--- a/conf/legacy_framesize.yaml
+++ b/conf/legacy_framesize.yaml
@@ -1,4 +1,4 @@
-# Version 2.0
+# Version 2.1
 globals:
   - id: room_temp_api_timeout
     type: int

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -1,4 +1,4 @@
-# Version 2.0
+# Version 2.1
 substitutions:
   # Unique device ID in HA
   deviceid: "mhi_ac_ctrl"

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -42,17 +42,6 @@ button:
     name: Restart
     entity_category: diagnostic
 
-climate:
-  - platform: custom
-    lambda: |-
-      auto mhi_ac_ctrl = new MhiAcCtrl();
-      App.register_component(mhi_ac_ctrl);
-      return {mhi_ac_ctrl};
-
-    climates:
-      - name: none  # HA will use the devicename -> climate.devicename
-        id: ${deviceid}
-
 api:
   reboot_timeout: 0s
   services:

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -74,21 +74,12 @@ api:
         - lambda: |-
             return ((MhiAcCtrl*)id(${deviceid}))->set_vanes(value);
 
-
 sensor:
   - platform: uptime
     name: Uptime
   - platform: wifi_signal
     name: WiFi Signal
     update_interval: 60s
-
-binary_sensor:
-  - platform: custom
-    lambda: |-
-      return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
-
-    binary_sensors:
-      - name: Defrost
 
 text_sensor:
   - platform: version
@@ -100,10 +91,4 @@ text_sensor:
       name: SSID
     bssid:
       name: BSSID
-  - platform: custom
-    lambda: |-
-      return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
-
-    text_sensors:
-      - name: Compressor protection status
 

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -17,11 +17,11 @@ esphome:
     - MHI-AC-Ctrl-core.h
     - MHI-AC-Ctrl-core.cpp
 
-# Enable this for current units, supporting the larger framesize
-# Comment if you encounter mhi_ac_ctrl_core.loop error: -2 errors and uncomment the legacy_framesize file
-<<: !include conf/large_framesize.yaml
-# Uncomment this to allow for a working configuration on floor units or older units
-# <<: !include conf/legacy_framesize.yaml
+packages:
+  # Comment if you encounter mhi_ac_ctrl_core.loop error: -2 errors and uncomment the legacy_framesize file
+  mhi-ac-ctrl: !include conf/large_framesize.yaml
+  # Uncomment this to allow for a working configuration on floor units or older units
+  # mhi-ac-ctrl: !include conf/legacy_framesize.yaml
 
 wifi:
   ssid: "**SSID**"
@@ -36,16 +36,6 @@ logger:
 
 ota:
 
-climate:
-  - platform: custom
-    lambda: |-
-      auto mhi_ac_ctrl = new MhiAcCtrl();
-      App.register_component(mhi_ac_ctrl);
-      return {mhi_ac_ctrl};
-
-    climates:
-      - name: "${devicename}"
-        id: ${deviceid}
 
 api:
   reboot_timeout: 0s
@@ -68,13 +58,12 @@ api:
         - lambda: |-
             return ((MhiAcCtrl*)id(${deviceid}))->set_vanes(value);
 
-binary_sensor:
-  - platform: custom
-    lambda: |-
-      return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
-
-    binary_sensors:
-      - name: ${devicename} defrost
+sensor:
+  - platform: uptime
+    name: ${devicename} Uptime
+  - platform: wifi_signal
+    name: ${devicename} WiFi Signal
+    update_interval: 60s
 
 text_sensor:
   - platform: version
@@ -86,11 +75,3 @@ text_sensor:
       name: ${devicename} SSID
     bssid:
       name: ${devicename} BSSID
-  - platform: custom
-    lambda: |-
-      return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
-
-    text_sensors:
-      - name: ${devicename} compressor protection status
-
-


### PR DESCRIPTION
This PR moves all entities related to the MHI-AC-Ctrl into the `conf/*.yaml` files. And any unrelated components out of them, and into the main `lr_mhi_ac_ctrl.yaml` config file.

These changes make it easier for users to include these config files in their own main device configuration without having to manually add the other entities such as the `defrost` and `compressor protection status`.
Entities unrelated to the MHI-AC-Ctrl (e.g. WiFi stats) have been moved out of these config files as they are not related to the core functionality that is provided by this component.

Top level inclusion is now done using `packages` (instead of the direct inclusion: `<<: !include`), which allows merging of e.g. the `sensors:` defined in multiple files when including. 

Re-structuring the config files like this makes it easier for users to include this repo as a Submodule in their EspHome config directories without the need to make in-repo changes or to copy-paste most of the config files into their own. This keeps the Submodule clean and easier to stay up to date with any future changes.

This also greatly simplifies the main config file.
( mine: )
```yaml

substitutions:
  # Unique device ID in HA
  deviceid: "mhi_ac_ctrl"
  # Unique device name in HA (sensor names will be prefixed by this name)
  devicename: "MHI-AC-Ctrl"

  friendly_name: ${devicename}
  hostname: "mhi-ac-ctrl"

packages:
  # Basic common boilerplate configuration:
  common: !include common/base_config.yaml
  # Use new 33B framesize to allow for Vanes control
  mhi-ac-ctrl: !include SubModules/MHI-AC-Ctrl-ESPHome/conf/large_framesize.yaml

esp8266:
  board: d1_mini

esphome:
  platformio_options:
    # Run CPU at 160Mhz to fix mhi_ac_ctrl_core.loop error: -2
    board_build.f_cpu: 160000000L
  includes:
    # https://github.com/ginkage/MHI-AC-Ctrl-ESPHome
    - SubModules/MHI-AC-Ctrl-ESPHome/mhi_ac_ctrl.h
    - SubModules/MHI-AC-Ctrl-ESPHome/MHI-AC-Ctrl-core.h
    - SubModules/MHI-AC-Ctrl-ESPHome/MHI-AC-Ctrl-core.cpp

api:
  services:
    # Call the set_vanes service from HA to set the vane position
    # Needed because the ESPHome Climate class does not support this natively
    # Possible values: 1-4: static positions, 5: swing, 0: unknown
    - service: set_vanes
      variables:
        value: int
      then:
        - lambda: |-
            return ((MhiAcCtrl*)id(${deviceid}))->set_vanes(value);

```