### PR TITLE
Enable energy dashboard usage for `energy_used` sensor

### DIFF
--- a/mhi_ac_ctrl.h
+++ b/mhi_ac_ctrl.h
@@ -122,6 +122,8 @@ public:
         energy_used_.set_icon("mdi:lightning-bolt");
         energy_used_.set_unit_of_measurement("kWh");
         energy_used_.set_accuracy_decimals(2);
+        energy_used_.set_device_class("energy");
+        energy_used_.set_state_class(STATE_CLASS_TOTAL_INCREASING);
 
         mhi_ac_ctrl_core.MHIAcCtrlStatus(this);
         mhi_ac_ctrl_core.init();


### PR DESCRIPTION
The `energy_used` sensor provided by MHI-AC-Ctrl-ESPHome cannot be used by the HA energy dashboard, as it doesn't have the correct `device_class` and `state_class` defined. This PR fixes that.

Tested locally, works fine.

Fixes #75 