### PR TITLE
Use HA entity naming convention

### DIFF
--- a/conf/large_framesize.yaml
+++ b/conf/large_framesize.yaml
@@ -11,9 +11,9 @@ globals:
 
 sensor:
   - platform: uptime
-    name: ${devicename} Uptime
+    name: Uptime
   - platform: wifi_signal
-    name: ${devicename} WiFi Signal
+    name: WiFi Signal
     update_interval: 60s
   - platform: custom
     lambda: |-
@@ -22,16 +22,16 @@ sensor:
     # Sensor names in HA, you can change these if you want
     # Don't delete them or change their position in the list
     sensors:
-      - name: ${devicename} error code
-      - name: ${devicename} outdoor temperature
-      - name: ${devicename} return air temperature
-      - name: ${devicename} outdoor unit fan speed
-      - name: ${devicename} indoor unit fan speed
-      - name: ${devicename} current power
-      - name: ${devicename} compressor frequency
-      - name: ${devicename} indoor unit total run time
-      - name: ${devicename} compressor total run time
-      - name: ${devicename} vanes
+      - name: Error code
+      - name: Outdoor temperature
+      - name: Return air temperature
+      - name: Outdoor unit fan speed
+      - name: Indoor unit fan speed
+      - name: Current power
+      - name: Compressor frequency
+      - name: Indoor unit total run time
+      - name: Compressor total run time
+      - name: Vanes
         id: vanes_UD_received
         on_value:
           then:
@@ -49,16 +49,16 @@ sensor:
                   id(fan_control_ud).publish_state("Swing");
                 }
 
-      - name: ${devicename} energy used
-      - name: ${devicename} Indoor (U-bend) HE temp 1
-      - name: ${devicename} Indoor (capillary) HE temp 2
-      - name: ${devicename} Indoor (suction header) HE temp 3
-      - name: ${devicename} Outdoor HE temp
-      - name: ${devicename} Outdoor unit exp. valve
-      - name: ${devicename} Outdoor unit discharge pipe
-      - name: ${devicename} Outdoor unit discharge pipe super heat
-      - name: ${devicename} compressor protection code
-      - name: ${devicename} Vanes Left Right
+      - name: Energy used
+      - name: Indoor (U-bend) HE temp 1
+      - name: Indoor (capillary) HE temp 2
+      - name: Indoor (suction header) HE temp 3
+      - name: Outdoor HE temp
+      - name: Outdoor unit exp. valve
+      - name: Outdoor unit discharge pipe
+      - name: Outdoor unit discharge pipe super heat
+      - name: Compressor protection code
+      - name: Vanes Left Right
         id: vanes_LR_received
         on_value:
           then:
@@ -81,7 +81,7 @@ sensor:
                 } else if (received_value == 8.0) {
                   id(fan_control_lr).publish_state("Swing");
                 }
-      - name: ${devicename} 3D Auto
+      - name: 3D Auto
         id: Dauto_received
         on_value:
           then:
@@ -98,7 +98,7 @@ sensor:
 
 select:
   - platform: template
-    name: ${devicename} Fan Control Left Right
+    name: Fan Control Left Right
     id: fan_control_lr
     icon: mdi:arrow-left-right
     optimistic: true
@@ -145,7 +145,7 @@ select:
           }
 
   - platform: template
-    name: ${devicename} Fan Control Up Down
+    name: Fan Control Up Down
     id: fan_control_ud
     icon: mdi:arrow-up-down
     optimistic: true
@@ -184,7 +184,7 @@ select:
 
 switch:
   - platform: template
-    name: ${devicename} 3D Auto
+    name: 3D Auto
     id: fan_control_3Dauto
     icon: mdi:video-3d
     optimistic: true

--- a/conf/legacy_framesize.yaml
+++ b/conf/legacy_framesize.yaml
@@ -11,9 +11,9 @@ globals:
 
 sensor:
   - platform: uptime
-    name: ${devicename} Uptime
+    name: Uptime
   - platform: wifi_signal
-    name: ${devicename} WiFi Signal
+    name: WiFi Signal
     update_interval: 60s
   - platform: custom
     lambda: |-
@@ -22,16 +22,16 @@ sensor:
     # Sensor names in HA, you can change these if you want
     # Don't delete them or change their position in the list
     sensors:
-      - name: ${devicename} error code
-      - name: ${devicename} outdoor temperature
-      - name: ${devicename} return air temperature
-      - name: ${devicename} outdoor unit fan speed
-      - name: ${devicename} indoor unit fan speed
-      - name: ${devicename} current power
-      - name: ${devicename} compressor frequency
-      - name: ${devicename} indoor unit total run time
-      - name: ${devicename} compressor total run time
-      - name: ${devicename} vanes
+      - name: Error code
+      - name: Outdoor temperature
+      - name: Return air temperature
+      - name: Outdoor unit fan speed
+      - name: Indoor unit fan speed
+      - name: Current power
+      - name: Compressor frequency
+      - name: Indoor unit total run time
+      - name: Compressor total run time
+      - name: Vanes
         id: vanes_UD_received
         on_value:
           then:
@@ -49,19 +49,19 @@ sensor:
                   id(fan_control_ud).publish_state("Swing");
                 }
 
-      - name: ${devicename} energy used
-      - name: ${devicename} Indoor (U-bend) HE temp 1
-      - name: ${devicename} Indoor (capillary) HE temp 2
-      - name: ${devicename} Indoor (suction header) HE temp 3
-      - name: ${devicename} Outdoor HE temp
-      - name: ${devicename} Outdoor unit exp. valve
-      - name: ${devicename} Outdoor unit discharge pipe
-      - name: ${devicename} Outdoor unit discharge pipe super heat
-      - name: ${devicename} Protection error state
+      - name: Energy used
+      - name: Indoor (U-bend) HE temp 1
+      - name: Indoor (capillary) HE temp 2
+      - name: Indoor (suction header) HE temp 3
+      - name: Outdoor HE temp
+      - name: Outdoor unit exp. valve
+      - name: Outdoor unit discharge pipe
+      - name: Outdoor unit discharge pipe super heat
+      - name: Protection error state
 
 select:
   - platform: template
-    name: ${devicename} Fan Control Up Down
+    name: Fan Control Up Down
     id: fan_control_ud
     icon: mdi:arrow-up-down
     optimistic: true

--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -2,11 +2,12 @@
 substitutions:
   # Unique device ID in HA
   deviceid: "mhi_ac_ctrl"
-  # Unique device name in HA (sensor names will be prefixed by this name)
+  # Unique device name in HA
   devicename: "MHI-AC-Ctrl"
 
 esphome:
-  name: lr_mhi_ac_ctrl
+  name: ${deviceid}
+  friendly_name: ${devicename}
   platform: ESP8266
   board: d1_mini
   platformio_options:
@@ -44,7 +45,7 @@ climate:
       return {mhi_ac_ctrl};
 
     climates:
-      - name: "${devicename}"
+      - name: none  # HA will use the devicename -> climate.devicename
         id: ${deviceid}
 
 api:
@@ -74,23 +75,23 @@ binary_sensor:
       return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
 
     binary_sensors:
-      - name: ${devicename} defrost
+      - name: Defrost
 
 text_sensor:
   - platform: version
-    name: ${devicename} ESPHome Version
+    name: ESPHome Version
   - platform: wifi_info
     ip_address:
-      name: ${devicename} IP
+      name: IP
     ssid:
-      name: ${devicename} SSID
+      name: SSID
     bssid:
-      name: ${devicename} BSSID
+      name: BSSID
   - platform: custom
     lambda: |-
       return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
 
     text_sensors:
-      - name: ${devicename} compressor protection status
+      - name: Compressor protection status
 
 


### PR DESCRIPTION
Adjusted the naming of entities in this project to align with the HA naming convention. No functional changes.

See https://developers.home-assistant.io/blog/2022/07/10/entity_naming/

![image](https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/assets/33529490/12953fa4-fb6e-4537-86e1-c6044caca6d1)

![image](https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/assets/33529490/51478ae3-9b42-49f8-9f11-8d703575c990)

BTW: one will need to remove the existing device and rediscover the device to make use of these changes
