### PR TITLE
Add restart button

### DIFF
--- a/lr_mhi_ac_ctrl.yaml
+++ b/lr_mhi_ac_ctrl.yaml
@@ -36,6 +36,11 @@ logger:
 
 ota:
 
+button:
+  - platform: restart
+    name: Restart
+    entity_category: diagnostic
+
 climate:
   - platform: custom
     lambda: |-
@@ -92,5 +97,3 @@ text_sensor:
 
     text_sensors:
       - name: ${devicename} compressor protection status
-
-


### PR DESCRIPTION
Subject says it all: this PR adds a restart button so the device can easily be restarted from HA.

![image](https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/assets/33529490/4ec385e5-8b16-49dd-97c1-c91505673a4a)

