### PR TITLE
Breakout platform from esphome component key

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -1,11 +1,12 @@
 esphome:
   name: example-ac
   friendly_name: ${devicename}
-  platform: ESP8266
-  board: d1_mini
   platformio_options:
     # Run CPU at 160Mhz to fix mhi_ac_ctrl_core.loop error: -2
     board_build.f_cpu: 160000000L
+
+esp8266:
+  board: d1_mini
 
 # Enable logging
 logger:


### PR DESCRIPTION
ESPHome recommends new projects to use the platform-specific sections for `esp8266` and `esp32` (see https://esphome.io/components/esphome#configuration-variables). 

_Old-style platform options, which have been moved to the platform-specific [esp32](https://esphome.io/components/esp32) and [esp8266](https://esphome.io/components/esp8266) sections but are still accepted here for compatibility reasons (usage not recommended for new projects)_

This change implements that in the `example.yaml`. Docs for new config options are here: https://esphome.io/components/esp8266.html

The old style is still working (so no breaking change), but I guessed it would be good to provide the current best practice in the example.