### PR TITLE
Add fan_modes to webserver and home assistant

### DIFF
--- a/components/MhiAcCtrl/mhi_ac_ctrl.h
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.h
@@ -96,7 +96,10 @@ public:
 
         defrost_.set_icon("mdi:snowflake-melt");
 
-        vanes_pos_.set_icon("mdi:air-filter");
+        vanes_pos_.set_icon("mdi:arrow-up-down");
+        vanesLR_pos_.set_icon("mdi:arrow-left-right");
+
+        Dauto_.set_icon("mdi:video-3d");
 
         indoor_unit_thi_r1_.set_icon("mdi:thermometer");
         indoor_unit_thi_r1_.set_unit_of_measurement("°C");
@@ -544,6 +547,11 @@ public:
     void set_vanesLR(int value) {
         mhi_ac_ctrl_core.set_vanesLR(value);
         ESP_LOGD("mhi_ac_ctrl", "set vanes Left Right: %i", value);
+    }
+
+    void set_fan(int value) {
+        mhi_ac_ctrl_core.set_fan(value);
+        ESP_LOGD("mhi_ac_ctrl", "set fan: %i", value);
     }
 
     void set_3Dauto(bool value) {

--- a/components/MhiAcCtrl/mhi_ac_ctrl.h
+++ b/components/MhiAcCtrl/mhi_ac_ctrl.h
@@ -549,11 +549,6 @@ public:
         ESP_LOGD("mhi_ac_ctrl", "set vanes Left Right: %i", value);
     }
 
-    void set_fan(int value) {
-        mhi_ac_ctrl_core.set_fan(value);
-        ESP_LOGD("mhi_ac_ctrl", "set fan: %i", value);
-    }
-
     void set_3Dauto(bool value) {
         // ESP_LOGD("mhi_ac_ctrl", "set 3D auto: %s", value);
         if (value){

--- a/confs/debug.yml
+++ b/confs/debug.yml
@@ -1,0 +1,25 @@
+# Example configuration entry
+debug:
+  update_interval: 5s
+
+text_sensor:
+  - platform: debug
+    reset_reason:
+      name: "Reset Reason"
+      entity_category: diagnostic
+    device:
+      name: "Device Info"
+      entity_category: diagnostic
+
+sensor:
+  - platform: debug
+    loop_time:
+      name: "Loop Time"
+      entity_category: diagnostic
+    free:
+      name: "Heap Free"
+      entity_category: diagnostic
+
+# Logger must be at least debug (default)
+logger:
+  level: debug

--- a/confs/labels-en.yml
+++ b/confs/labels-en.yml
@@ -1,0 +1,54 @@
+substitutions:
+  restart: ESP Restart
+  defrost: Defrost
+  status: Status
+  framesize: Frame size
+  error_code: Error code
+  outdoor_temperature: Outdoor temperature
+  return_air_temperature: Return air temperature
+  outdoor_unit_fan_speed: Outdoor unit fan speed
+  indoor_unit_fan_speed: Indoor unit fan speed
+  compressor_current: Compressor current
+  compressor_power: Compressor power
+  compressor_frequency: Compressor frequency
+  indoor_unit_total_run_time: Indoor unit total run time
+  outdoor_unit_total_run_time: Outdoor unit total run time
+  vanes_up_down: Vanes Up Down
+  up: Up
+  up_center: Up/Center
+  center_down: Center/Down
+  down: Down
+  swing: Swing
+  energy_used: Energy used
+  indoor_unit_u_bend_he_temp_1: Indoor unit (U-bend) HE temp 1
+  indoor_unit_capillary_he_temp_2: Indoor unit (capillary) HE temp 2
+  indoor_unit_suction_header_he_temp_3: Indoor unit (suction header) HE temp 3
+  outdoor_unit_he_temp: Outdoor unit HE temp
+  outdoor_unit_exp_valve: Outdoor unit exp. valve
+  outdoor_unit_discharge_pipe: Outdoor unit discharge pipe
+  outdoor_unit_discharge_pipe_super_heat: Outdoor unit discharge pipe super heat
+  compressor_protection_code: Compressor protection code
+  vanes_left_right: Vanes Left Right
+  left: Left
+  left_center: Left/Center
+  center: Center
+  center_right: Center/Right
+  right: Right
+  wide: Wide
+  spot: Spot
+  d_auto: 3D Auto
+  fan_speed: Fan speed
+  quiet: Quiet
+  low: Low
+  medium: Medium
+  high: High
+  auto: Auto
+  compressor_protection_status: Compressor protection status
+  vanes_control_left_right: Vanes Control Left Right
+  vanes_control_up_down: Vanes Control Up Down
+  operation: Operation
+  control: Control
+  ext_temperature: Temperature
+  ext_temperature_control: Temperature Control
+  ext_mhi: Mhi
+  ext_external: External

--- a/confs/labels-nl.yml
+++ b/confs/labels-nl.yml
@@ -1,0 +1,54 @@
+substitutions:
+  restart: ESP Herstart
+  defrost: Ontdooien
+  status: Status
+  framesize: Frame grootte
+  error_code: Fout code
+  outdoor_temperature: Buiten temperatuur
+  return_air_temperature: Binnenunit retour temperatuur
+  outdoor_unit_fan_speed: Buitenunit fansnelheid
+  indoor_unit_fan_speed: Binnenunit fansnelheid
+  compressor_current: Compressor stroom
+  compressor_power: Compressor vermogen
+  compressor_frequency: Compressor frequentie
+  indoor_unit_total_run_time: Binnenunit draaiuren
+  outdoor_unit_total_run_time: Buitenunit draaiuren
+  vanes_up_down: Lamellen b/o
+  up: Boven
+  up_center: Boven midden
+  center_down: Midden onder
+  down: Onder
+  swing: Bewegen
+  energy_used: Energie verbruikt
+  indoor_unit_u_bend_he_temp_1: Binnenunit U-bocht HE temp 1
+  indoor_unit_capillary_he_temp_2: Binnenunit Capilair HE temp 2
+  indoor_unit_suction_header_he_temp_3: Binnenunit zuigheader HE temp 3
+  outdoor_unit_he_temp: Buitenunit HE temp
+  outdoor_unit_exp_valve: Buitenunit exp klep
+  outdoor_unit_discharge_pipe: Buitenunit afvoerleiding
+  outdoor_unit_discharge_pipe_super_heat: Buitenunit afvoerleiding oververh.
+  compressor_protection_code: Compressor beschermings code
+  vanes_left_right: Lamellen l/r
+  left: Links
+  left_center: Midden links
+  center: Midden
+  center_right: Midden rechts
+  right: Rechts
+  wide: Breed
+  spot: Spot
+  d_auto: 3D Auto
+  fan_speed: Fan
+  quiet: Stil
+  low: Laag
+  medium: Gemiddeld
+  high: Hoog
+  auto: Auto
+  compressor_protection_status: Compressor beschermings status
+  vanes_control_left_right: Lamellen l/r 
+  vanes_control_up_down: Lamellen b/o
+  operation: Meetgegevens
+  control: Bediening
+  ext_temperature: Temperatuur
+  ext_temperature_control: Temperatuur controle
+  ext_mhi: Mhi
+  ext_external: Extern

--- a/confs/onewire.yml
+++ b/confs/onewire.yml
@@ -1,0 +1,39 @@
+## Optional: DS18B20 for extra room sensor
+one_wire:
+  - platform: gpio
+    pin: GPIO5
+
+sensor:
+  ## optional: DS18B20 room sensor on PCB
+  - platform: dallas_temp
+    name: ${ext_temperature}
+    id: room_temperature
+    icon: mdi:thermometer
+    update_interval: 30s
+    device_class: temperature
+    state_class: measurement 
+
+## Override the room temperature from AC with external value from sensor connected to I2C grove port
+select:
+  - id: update_temp_i2c
+    name: ${ext_temperature_control}
+    icon: mdi:chart-bell-curve-cumulative
+    platform: template
+    options:
+      - "${ext_mhi}"
+      - "${ext_external}"
+    initial_option: "${ext_mhi}"
+    optimistic: true
+    restore_value: true
+    entity_category: config
+    update_interval: never
+
+interval:
+  - interval: 30s
+    then:
+      - if:
+          condition:
+            - lambda: 'return id(update_temp_i2c).state == "${ext_external}";'
+          then:
+            - lambda: |-
+                return ((MhiAcCtrl*)id(${deviceid}))->set_room_temperature(id(room_temperature).state);

--- a/confs/onewire.yml
+++ b/confs/onewire.yml
@@ -1,7 +1,7 @@
 ## Optional: DS18B20 for extra room sensor
 one_wire:
   - platform: gpio
-    pin: GPIO5
+    pin: D2
 
 sensor:
   ## optional: DS18B20 room sensor on PCB

--- a/confs/wifi-info.yml
+++ b/confs/wifi-info.yml
@@ -1,0 +1,47 @@
+sensor:
+## Diagnostics wifi and uptime
+  - platform: wifi_signal # Reports the WiFi signal strength/RSSI in dB
+    id: wifi_signal_db
+    name: WiFi Signal db
+    update_interval: 60s
+    device_class: signal_strength
+    entity_category: diagnostic
+    internal: true
+    icon: mdi:wifi
+
+  - platform: copy # Reports the WiFi signal strength in %
+    source_id: wifi_signal_db
+    id: wifi_signal_db_percent
+    name: WiFi Signal
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: " %"
+    entity_category: diagnostic
+    device_class: ""
+    icon: mdi:wifi
+
+  - platform: uptime
+    id: mhi_uptime
+    name: Uptime
+    unit_of_measurement: days
+    update_interval: 3600s
+    accuracy_decimals: 1
+    filters:
+      - multiply: 0.000011574
+    entity_category: diagnostic
+
+text_sensor:
+  - platform: version
+    name: ESPHome Version
+    entity_category: diagnostic
+    hide_timestamp: true
+
+  - platform: wifi_info
+    ip_address:
+      name: IP
+      icon: mdi:ip
+      entity_category: diagnostic
+    ssid:
+      name: SIDD
+      icon: mdi:wifi
+      entity_category: diagnostic

--- a/example.yaml
+++ b/example.yaml
@@ -28,7 +28,7 @@ wifi:
   ap:
     ssid: ${devicename}
     password: "iTM7a3slpwsL"
-    ap_timeout: 15s
+    ap_timeout: 30s
 
 captive_portal:
     

--- a/example.yaml
+++ b/example.yaml
@@ -150,8 +150,8 @@ sensor:
                 } else if (received_value == 6.0) {
                   id(fan_speed).publish_state("Auto");
                 }
-      - name: Compressor amperage
-        id: compressor_amperage
+      - name: Compressor current
+        id: compressor_current
       - name: Compressor frequency
       - name: Indoor unit total run time
       - name: Compressor total run time
@@ -233,7 +233,7 @@ sensor:
     device_class: power
     state_class: measurement 
     accuracy_decimals: 0
-    lambda: return id(compressor_amperage).state * 230;
+    lambda: return id(compressor_current).state * 230;
 
 
 text_sensor:

--- a/example.yaml
+++ b/example.yaml
@@ -135,21 +135,6 @@ sensor:
       - name: Outdoor unit fan speed
       - name: Indoor unit fan speed
         id: indoor_unit_fan_speed
-        on_value:
-          then:
-            - lambda: |-
-                float received_value = id(indoor_unit_fan_speed).state;
-                if (received_value == 2.0) {
-                  id(fan_speed).publish_state("Quiet");
-                } else if (received_value == 3.0) {
-                  id(fan_speed).publish_state("Low");
-                } else if (received_value == 4.0) {
-                  id(fan_speed).publish_state("Medium");
-                } else if (received_value == 5.0) {
-                  id(fan_speed).publish_state("High");
-                } else if (received_value == 6.0) {
-                  id(fan_speed).publish_state("Auto");
-                }
       - name: Compressor current
         id: compressor_current
       - name: Compressor frequency
@@ -235,7 +220,32 @@ sensor:
     accuracy_decimals: 0
     lambda: return id(compressor_current).state * 230;
 
-
+  - platform: template
+    name: "Fan mode value"
+    id: fan_mode_value
+    entity_category: DIAGNOSTIC
+    internal: true
+    lambda: |-
+      auto new_value = id(${deviceid}).fan_mode.value();
+      if (id(fan_mode_value).state == new_value) {
+          return {};  // No state change needed
+      } else {
+          ESP_LOGD("main", "NEW value do something");
+          if (new_value == 9.0) {
+            id(fan_speed).publish_state("${quiet}");
+          } else if (new_value == 3.0) {
+            id(fan_speed).publish_state("${low}");
+          } else if (new_value == 4.0) {
+            id(fan_speed).publish_state("${medium}");
+          } else if (new_value == 5.0) {
+            id(fan_speed).publish_state("${high}");
+          } else if (new_value == 2.0) {
+            id(fan_speed).publish_state("${auto}");
+          }
+          return new_value;  // Update the state with the new value
+      }      
+    update_interval: 30s
+    
 text_sensor:
   - platform: version
     name: ESPHome Version
@@ -344,41 +354,33 @@ select:
 
   - platform: template
     id: fan_speed
-    name: Fan speed
+    name: ${fan_speed}
     icon: mdi:fan
     entity_category: config
     optimistic: true
     internal: false  
     options:
-     - "Quiet"
-     - "Low"
-     - "Medium"
-     - "High"
-     - "Auto"
-#    initial_option: "${auto}"
+     - "${quiet}"
+     - "${low}"
+     - "${medium}"
+     - "${high}"
+     - "${auto}"
     on_value:
-      - lambda: |-
-          auto state = id(fan_speed).state.c_str();
-          ESP_LOGD("main", "Option of my select: %s", state);
-          uint8_t fan_ = 0;  // Initialize the fan_ variable
-          if (id(fan_speed).state == "Quiet") {
-            fan_ = 0;
-          } else if (id(fan_speed).state == "Low") {
-            fan_ = 1;
-          } else if (id(fan_speed).state == "Medium") {
-            fan_ = 2;
-          } else if (id(fan_speed).state == "High") {
-            fan_ = 6;
-          } else if (id(fan_speed).state == "Auto") {
-            fan_ = 7;
-          }
-          if ((fan_ >= 0) & (fan_ < 8)){
-            ESP_LOGD("main", "setting fan_speed to: %i", fan_);
-            return ((MhiAcCtrl*)id(${deviceid}))->set_fan(fan_);
-          }
-          else {
-            ESP_LOGD("main", "Not setting fan_speed: %i", fan_);
-          }
+      then:
+        - climate.control:
+            id: ${deviceid}
+            fan_mode: !lambda |-
+                if (i == 0) {
+                  return CLIMATE_FAN_QUIET;
+                } else if (i == 1) {
+                  return CLIMATE_FAN_LOW;
+                } else if (i == 2) {
+                  return CLIMATE_FAN_MEDIUM;
+                } else if (i == 3) {
+                  return CLIMATE_FAN_HIGH;
+                } else {
+                  return CLIMATE_FAN_AUTO;
+                }
 
 switch:
   - platform: template

--- a/example.yaml
+++ b/example.yaml
@@ -352,7 +352,7 @@ select:
 
   - platform: template
     id: fan_speed
-    name: ${fan_speed}
+    name: Fan speed
     icon: mdi:fan
     entity_category: config
     optimistic: true

--- a/example.yaml
+++ b/example.yaml
@@ -140,15 +140,15 @@ sensor:
             - lambda: |-
                 float received_value = id(indoor_unit_fan_speed).state;
                 if (received_value == 2.0) {
-                  id(fan_speed).publish_state("quiet");
+                  id(fan_speed).publish_state("Quiet");
                 } else if (received_value == 3.0) {
-                  id(fan_speed).publish_state("low");
+                  id(fan_speed).publish_state("Low");
                 } else if (received_value == 4.0) {
-                  id(fan_speed).publish_state("medium");
+                  id(fan_speed).publish_state("Medium");
                 } else if (received_value == 5.0) {
-                  id(fan_speed).publish_state("high");
+                  id(fan_speed).publish_state("High");
                 } else if (received_value == 6.0) {
-                  id(fan_speed).publish_state("auto");
+                  id(fan_speed).publish_state("Auto");
                 }
       - name: Compressor amperage
         id: compressor_amperage
@@ -350,26 +350,26 @@ select:
     optimistic: true
     internal: false  
     options:
-     - "quiet"
-     - "low"
-     - "medium"
-     - "high"
-     - "auto"
+     - "Quiet"
+     - "Low"
+     - "Medium"
+     - "High"
+     - "Auto"
 #    initial_option: "${auto}"
     on_value:
       - lambda: |-
           auto state = id(fan_speed).state.c_str();
           ESP_LOGD("main", "Option of my select: %s", state);
-          uint8_t fan_ = 0;  // Initialize the vanesUD variable
-          if (id(fan_speed).state == "quiet") {
+          uint8_t fan_ = 0;  // Initialize the fan_ variable
+          if (id(fan_speed).state == "Quiet") {
             fan_ = 0;
-          } else if (id(fan_speed).state == "low") {
+          } else if (id(fan_speed).state == "Low") {
             fan_ = 1;
-          } else if (id(fan_speed).state == "medium") {
+          } else if (id(fan_speed).state == "Medium") {
             fan_ = 2;
-          } else if (id(fan_speed).state == "high") {
+          } else if (id(fan_speed).state == "High") {
             fan_ = 6;
-          } else if (id(fan_speed).state == "auto") {
+          } else if (id(fan_speed).state == "Auto") {
             fan_ = 7;
           }
           if ((fan_ >= 0) & (fan_ < 8)){

--- a/example.yaml
+++ b/example.yaml
@@ -45,7 +45,7 @@ wifi:
 captive_portal:
     
 # Optionally enables the ESP web server
-webserver:
+web_server:
   port: 80
   version: 3
   include_internal: true

--- a/example.yaml
+++ b/example.yaml
@@ -112,8 +112,10 @@ sensor:
   - platform: template
     name: "Frame Size"
     id: frame_size_sensor
+    icon: mdi:arrow-expand-horizontal
     lambda: |-
       return ${frame_size};
+    entity_category: diagnostic
   - platform: uptime
     name: Uptime
   - platform: wifi_signal
@@ -131,7 +133,24 @@ sensor:
       - name: Return air temperature
       - name: Outdoor unit fan speed
       - name: Indoor unit fan speed
-      - name: Current power
+        id: indoor_unit_fan_speed
+        on_value:
+          then:
+            - lambda: |-
+                float received_value = id(indoor_unit_fan_speed).state;
+                if (received_value == 2.0) {
+                  id(fan_speed).publish_state("quiet");
+                } else if (received_value == 3.0) {
+                  id(fan_speed).publish_state("low");
+                } else if (received_value == 4.0) {
+                  id(fan_speed).publish_state("medium");
+                } else if (received_value == 5.0) {
+                  id(fan_speed).publish_state("high");
+                } else if (received_value == 6.0) {
+                  id(fan_speed).publish_state("auto");
+                }
+      - name: Compressor amperage
+        id: compressor_amperage
       - name: Compressor frequency
       - name: Indoor unit total run time
       - name: Compressor total run time
@@ -205,6 +224,16 @@ sensor:
                   ESP_LOGD("main", "received 3DAuto off from AC");
                   id(fan_control_3Dauto).publish_state(false);
                 }
+  - platform: template
+    name: Compressor power
+    id: power
+    icon: mdi:flash
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement 
+    accuracy_decimals: 0
+    lambda: return id(compressor_amperage).state * 230;
+
 
 text_sensor:
   - platform: version
@@ -227,6 +256,7 @@ select:
     name: Fan Control Left Right
     id: fan_control_lr
     icon: mdi:arrow-left-right
+    entity_category: config
     optimistic: true
     options:
       # - "3D Auto"
@@ -276,6 +306,7 @@ select:
     name: Fan Control Up Down
     id: fan_control_ud
     icon: mdi:arrow-up-down
+    entity_category: config
     optimistic: true
     options:
       # - "3D Auto"
@@ -308,6 +339,44 @@ select:
           }
           else {
             ESP_LOGD("main", "Not setting vanesUD: %i", vanesUD);
+          }
+
+  - platform: template
+    id: fan_speed
+    name: ${fan_speed}
+    icon: mdi:fan
+    entity_category: config
+    optimistic: true
+    internal: false  
+    options:
+     - "quiet"
+     - "low"
+     - "medium"
+     - "high"
+     - "auto"
+#    initial_option: "${auto}"
+    on_value:
+      - lambda: |-
+          auto state = id(fan_speed).state.c_str();
+          ESP_LOGD("main", "Option of my select: %s", state);
+          uint8_t fan_ = 0;  // Initialize the vanesUD variable
+          if (id(fan_speed).state == "quiet") {
+            fan_ = 0;
+          } else if (id(fan_speed).state == "low") {
+            fan_ = 1;
+          } else if (id(fan_speed).state == "medium") {
+            fan_ = 2;
+          } else if (id(fan_speed).state == "high") {
+            fan_ = 6;
+          } else if (id(fan_speed).state == "auto") {
+            fan_ = 7;
+          }
+          if ((fan_ >= 0) & (fan_ < 8)){
+            ESP_LOGD("main", "setting fan_speed to: %i", fan_);
+            return ((MhiAcCtrl*)id(${deviceid}))->set_fan(fan_);
+          }
+          else {
+            ESP_LOGD("main", "Not setting fan_speed: %i", fan_);
           }
 
 switch:

--- a/example.yaml
+++ b/example.yaml
@@ -28,6 +28,7 @@ wifi:
   ap:
     ssid: ${devicename}
     password: "iTM7a3slpwsL"
+    ap_timeout: 15s
 
 captive_portal:
     
@@ -343,7 +344,7 @@ select:
 
   - platform: template
     id: fan_speed
-    name: ${fan_speed}
+    name: Fan speed
     icon: mdi:fan
     entity_category: config
     optimistic: true

--- a/example.yaml
+++ b/example.yaml
@@ -1,5 +1,17 @@
+# Version 3.2 Wemos d1 mini
+substitutions:
+  # Unique device ID in HA
+  deviceid: "ac_example" #deviceid: "example_ac" 14 char. is maximum
+  # Unique MHI device ID used for climate class
+  mhi_device_id: "mhi_${deviceid}"
+  # Unique device name in HA (sensor names will be prefixed by this name)
+  devicename: "AC Example" #devicename: ${deviceid}
+  # If you encounter mhi_ac_ctrl_core.loop error: -2 errors, change the frame_size from 33 to 20
+  # Remark: with frame_size 20 3D Auto and vanes left/right dont work anymore
+  frame_size: "33"
+
 esphome:
-  name: example-ac
+  name: ac-example #name: example-ac
   friendly_name: ${devicename}
   min_version: 2024.6.0
   platformio_options:
@@ -11,14 +23,14 @@ esp8266:
 
 # Enable logging
 logger:
-  level: INFO
-  baud_rate: 0
-  # logs:
-  #   component: ERROR
+  level: DEBUG  ## or choose INFO for less logging messages
+  logs:
+    component: ERROR    ## to remove component MhiAcCtrl took long time - warnings
+    #mhi_ac_ctrl: ERROR  ## to remove mhi_ac_ctrl_core.loop error: -2 - warnings
 
 ota:
-  password: <PLEASE SUPPLY PASSWORD>
   platform: esphome
+  #password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid
@@ -27,31 +39,46 @@ wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: ${devicename}
-    password: "iTM7a3slpwsL"
+    password: "configesp"
     ap_timeout: 30s
 
 captive_portal:
     
-# Version 3.0
-
-substitutions:
-  # Unique device ID in HA
-  deviceid: "example_ac"
-  # Unique MHI device ID used for climate class
-  mhi_device_id: "mhi_${deviceid}"
-  # Unique device name in HA (sensor names will be prefixed by this name)
-  devicename: ${deviceid}
-  # If you encounter mhi_ac_ctrl_core.loop error: -2 errors, change the frame_size to 20
-  frame_size: "33"
-
-
 # Optionally enables the ESP web server
-# web_server:
-#   port: 80
+webserver:
+  port: 80
+  version: 3
+  include_internal: true
+  ota: false
+  local: true
+  sorting_groups:
+    - id: Control
+      name: "${control}"
+      sorting_weight: -30
+    - id: Operation
+      name: "${operation}"
+      sorting_weight: -20
+    - id: Status
+      name: "${status}"
+      sorting_weight: -10
 
 external_components:
-  - source: github://ginkage/MHI-AC-Ctrl-ESPHome@master
+  - source: github://fonske/MHI-AC-Ctrl-ESPHome@master
     components: [ MhiAcCtrl ]
+
+## remote options
+packages:
+  remote_package:
+    url: https://github.com/fonske/MHI-AC-Ctrl-ESPHome/
+    ref: master
+    refresh: always
+    files: [ 
+            #confs/onewire.yml,
+            #confs/debug.yml,
+            confs/wifi-info.yml,
+            confs/labels-en.yml,
+            #confs/labels-nl.yml,
+           ]
 
 MhiAcCtrl:
   id: ${mhi_device_id}
@@ -61,24 +88,28 @@ MhiAcCtrl:
 
 button:
   - platform: restart
-    name: Restart
+    name: ${restart}
     entity_category: diagnostic
+    icon: mdi:button-pointer
 
+# Enable Home Assistant API
 api:
   reboot_timeout: 0s
-  services:
-    # Call the set_api_room_temperature service from HA to override the room temperature
-    # If a new value has not been received after room_temp_api_timeout seconds, it will fall back to internal sensor
-    - service: set_api_room_temperature
+  #encryption:
+    #key: !secret api_encryption_key
+  actions:
+    ## Call the set_api_room_temperature action from HA to override the room temperature
+    ## If a new value has not been received after room_temp_api_timeout seconds, it will fall back to internal sensor
+    - action: set_api_room_temperature
       variables:
         value: float
       then:
         - lambda: |-
             return ((MhiAcCtrl*)id(${deviceid}))->set_room_temperature(value);
-    # Call the set_vanes service from HA to set the vane position
-    # Needed because the ESPHome Climate class does not support this natively
-    # Possible values: 1-4: static positions, 5: swing, 0: unknown
-    - service: set_vanes
+    ## Call the set_vanes action from HA to set the vane position
+    ## Needed because the ESPHome Climate class does not support this natively
+    ## Possible values: 1-4: static positions, 5: swing, 0: unknown
+    - action: set_vanes
       variables:
         value: int
       then:
@@ -100,6 +131,12 @@ climate:
     mhi_ac_ctrl_id: ${mhi_device_id}
     id: ${deviceid}
     name: "${devicename}"
+    entity_category: config
+    icon: mdi:thermostat
+    ## Sorting grouping code only activate when package webserver is activated above
+    web_server:
+      sorting_group_id: Control
+      sorting_weight: 1
 
 binary_sensor:
   - platform: custom
@@ -107,21 +144,27 @@ binary_sensor:
       return ((MhiAcCtrl*)id(${deviceid}))->get_binary_sensors();
 
     binary_sensors:
-      - name: Defrost
+      - name: ${defrost}
+        icon: mdi:snowflake-melt
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 13
+
+  - platform: status
+    name: ${status}
+    icon: mdi:state-machine
+    entity_category: diagnostic
 
 sensor:
   - platform: template
-    name: "Frame Size"
+    name: ${framesize}
     id: frame_size_sensor
     icon: mdi:arrow-expand-horizontal
     lambda: |-
       return ${frame_size};
     entity_category: diagnostic
-  - platform: uptime
-    name: Uptime
-  - platform: wifi_signal
-    name: WiFi Signal
-    update_interval: 60s
+    update_interval: never
+
   - platform: custom
     lambda: |-
       return ((MhiAcCtrl*)id(${deviceid}))->get_sensors();
@@ -129,44 +172,98 @@ sensor:
     # Sensor names in HA, you can change these if you want
     # Don't delete them or change their position in the list
     sensors:
-      - name: Error code
-      - name: Outdoor temperature
-      - name: Return air temperature
-      - name: Outdoor unit fan speed
-      - name: Indoor unit fan speed
-      - name: Compressor current
+      - name: ${error_code}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 8
+      - name: ${outdoor_temperature}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 5
+      - name: ${return_air_temperature}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 1
+      - name: ${outdoor_unit_fan_speed}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 2
+      - name: ${indoor_unit_fan_speed}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 1
+      - name: ${compressor_current}
         id: compressor_current
-      - name: Compressor frequency
-      - name: Indoor unit total run time
-      - name: Compressor total run time
-      - name: Vanes
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 9
+      - name: ${compressor_frequency}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 8
+      - name: ${indoor_unit_total_run_time}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 3
+      - name: ${outdoor_unit_total_run_time}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 4
+      - name: ${vanes_up_down}
         id: vanes_UD_received
         on_value:
           then:
             - lambda: |-
                 float received_value = id(vanes_UD_received).state;
                 if (received_value == 1.0) {
-                  id(fan_control_ud).publish_state("Up");
+                  id(vanes_control_ud).publish_state("${up}");
                 } else if (received_value == 2.0) {
-                  id(fan_control_ud).publish_state("Up/Center");
+                  id(vanes_control_ud).publish_state("${up_center}");
                 } else if (received_value == 3.0) {
-                  id(fan_control_ud).publish_state("Center/Down");
+                  id(vanes_control_ud).publish_state("${center_down}");
                 } else if (received_value == 4.0) {
-                  id(fan_control_ud).publish_state("Down");
+                  id(vanes_control_ud).publish_state("${down}");
                 } else if (received_value == 5.0) {
-                  id(fan_control_ud).publish_state("Swing");
+                  id(vanes_control_ud).publish_state("${swing}");
                 }
 
-      - name: Energy used
-      - name: Indoor (U-bend) HE temp 1
-      - name: Indoor (capillary) HE temp 2
-      - name: Indoor (suction header) HE temp 3
-      - name: Outdoor HE temp
-      - name: Outdoor unit exp. valve
-      - name: Outdoor unit discharge pipe
-      - name: Outdoor unit discharge pipe super heat
-      - name: Compressor protection code
-      - name: Vanes Left Right
+      - name: ${energy_used}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 12
+      - name: ${indoor_unit_u_bend_he_temp_1}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 2
+      - name: ${indoor_unit_capillary_he_temp_2}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 3
+      - name: ${indoor_unit_suction_header_he_temp_3}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 4
+      - name: ${outdoor_unit_he_temp}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 6
+      - name: ${outdoor_unit_exp_valve}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 5
+      - name: ${outdoor_unit_discharge_pipe}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 7
+      - name: ${outdoor_unit_discharge_pipe_super_heat}
+        web_server:
+          sorting_group_id: Operation
+          sorting_weight: 8
+      - name: ${compressor_protection_code}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 6
+      - name: ${vanes_left_right}
         id: vanes_LR_received
         on_value:
           then:
@@ -176,23 +273,23 @@ sensor:
                 }
                 float received_value = id(vanes_LR_received).state;
                 if (received_value == 1.0) {
-                  id(fan_control_lr).publish_state("Left");
+                  id(vanes_control_lr).publish_state("${left}");
                 } else if (received_value == 2.0) {
-                  id(fan_control_lr).publish_state("Left/Center");
+                  id(vanes_control_lr).publish_state("${left_center}");
                 } else if (received_value == 3.0) {
-                  id(fan_control_lr).publish_state("Center");
+                  id(vanes_control_lr).publish_state("${center}");
                 } else if (received_value == 4.0) {
-                  id(fan_control_lr).publish_state("Center/Right");
+                  id(vanes_control_lr).publish_state("${center_right}");
                 } else if (received_value == 5.0) {
-                  id(fan_control_lr).publish_state("Right");
+                  id(vanes_control_lr).publish_state("${right}");
                 } else if (received_value == 6.0) {
-                  id(fan_control_lr).publish_state("Wide");
+                  id(vanes_control_lr).publish_state("${wide}");
                 } else if (received_value == 7.0) {
-                  id(fan_control_lr).publish_state("Spot");
+                  id(vanes_control_lr).publish_state("${spot}");
                 } else if (received_value == 8.0) {
-                  id(fan_control_lr).publish_state("Swing");
+                  id(vanes_control_lr).publish_state("${swing}");
                 }
-      - name: 3D Auto
+      - name: ${d_auto}
         id: Dauto_received
         on_value:
           then:
@@ -209,8 +306,10 @@ sensor:
                   ESP_LOGD("main", "received 3DAuto off from AC");
                   id(fan_control_3Dauto).publish_state(false);
                 }
+
+
   - platform: template
-    name: Compressor power
+    name: ${compressor_power}
     id: power
     icon: mdi:flash
     unit_of_measurement: W
@@ -218,6 +317,9 @@ sensor:
     state_class: measurement 
     accuracy_decimals: 0
     lambda: return id(compressor_current).state * 230;
+    web_server:
+      sorting_group_id: Operation
+      sorting_weight: 10
 
   - platform: template
     id: fan_mode_value
@@ -230,76 +332,70 @@ sensor:
       } else {
           ESP_LOGD("main", "NEW value do something");
           if (new_value == 9.0) {
-            id(fan_speed).publish_state("Quiet");
+            id(fan_speed).publish_state("${quiet}");
           } else if (new_value == 3.0) {
-            id(fan_speed).publish_state("Low");
+            id(fan_speed).publish_state("${low}");
           } else if (new_value == 4.0) {
-            id(fan_speed).publish_state("Medium");
+            id(fan_speed).publish_state("${medium}");
           } else if (new_value == 5.0) {
-            id(fan_speed).publish_state("High");
+            id(fan_speed).publish_state("${high}");
           } else if (new_value == 2.0) {
-            id(fan_speed).publish_state("Auto");
+            id(fan_speed).publish_state("${auto}");
           }
           return new_value;  // Update the state with the new value
       }      
     update_interval: 30s
 
 text_sensor:
-  - platform: version
-    name: ESPHome Version
-  - platform: wifi_info
-    ip_address:
-      name: IP
-    ssid:
-      name: SSID
-    bssid:
-      name: BSSID
   - platform: custom
     lambda: |-
       return ((MhiAcCtrl*)id(${deviceid}))->get_text_sensors();
     text_sensors:
-      - name: Compressor protection status
+      - name: ${compressor_protection_status}
+        web_server:
+          sorting_group_id: Status
+          sorting_weight: 7
 
 select:
   - platform: template
-    name: Fan Control Left Right
-    id: fan_control_lr
+    name: ${vanes_control_left_right}
+    id: vanes_control_lr
     icon: mdi:arrow-left-right
     entity_category: config
     optimistic: true
     options:
       # - "3D Auto"
-      - "Left"
-      - "Left/Center"
-      - "Center"
-      - "Center/Right"
-      - "Right"
-      - "Wide"
-      - "Spot"
-      - "Swing"
+      - "${left}"
+      - "${left_center}"
+      - "${center}"
+      - "${center_right}"
+      - "${right}"
+      - "${wide}"
+      - "${spot}"
+      - "${swing}"
     on_value:
       - lambda: |-
           if (id(frame_size_sensor).state == 33) {
-            auto state = id(fan_control_lr).state.c_str();
+            auto state = id(vanes_control_lr).state.c_str();
             ESP_LOGD("main", "Option of my select: %s", state);
             uint8_t vanesLR = 0;  // Initialize the vanesLR variable
-            if (id(fan_control_lr).state == "3D Auto") {
+            if (id(vanes_control_lr).state == "3D Auto") {
               id(fan_control_3Dauto).publish_state(true);
-            } else if (id(fan_control_lr).state == "Left") {
+            } else if (id(vanes_control_lr).state == "${left}") {
               vanesLR = 1;
-            } else if (id(fan_control_lr).state == "Left/Center") {
+            } else if (id(vanes_control_lr).state == "${left_center}") {
               vanesLR = 2;
-            } else if (id(fan_control_lr).state == "Center") {
+            } else if (id(vanes_control_lr).state == "${center}") {
               vanesLR = 3;
-            } else if (id(fan_control_lr).state == "Center/Right") {
+            } else if (id(vanes_control_lr).state == "${center_right}") {
               vanesLR = 4;
-            } else if (id(fan_control_lr).state == "Right") {
+            } else if (id(vanes_control_lr).state == "${right}") {
               vanesLR = 5;
-            } else if (id(fan_control_lr).state == "Wide") {
+            } else if (id(vanes_control_lr).state == "${wide}") {
               vanesLR = 6;
-            } else if (id(fan_control_lr).state == "Spot") {
+            } else if (id(vanes_control_lr).state == "${spot}") {
               vanesLR = 7;
-            } else if (id(fan_control_lr).state == "Swing") {
+            } else if (id(vanes_control_lr).state == "${swing}") {
               vanesLR = 8;
             }
             if ((vanesLR > 0) & (vanesLR < 9) & (vanesLR != id(vanes_LR_received).state)){
@@ -310,36 +406,40 @@ select:
               ESP_LOGD("main", "Not setting vanesLR: %i", vanesLR);
             }
           }
+    web_server:
+      sorting_group_id: Control
+      sorting_weight: 3
+
 
   - platform: template
-    name: Fan Control Up Down
-    id: fan_control_ud
+    name: ${vanes_control_up_down}
+    id: vanes_control_ud
     icon: mdi:arrow-up-down
     entity_category: config
     optimistic: true
     options:
-      # - "3D Auto"
-      - "Up"
-      - "Up/Center"
-      - "Center/Down"
-      - "Down"
-      - "Swing"
+      # - "${d_auto}"
+      - "${up}"
+      - "${up_center}"
+      - "${center_down}"
+      - "${down}"
+      - "${swing}"
     on_value:
       - lambda: |-
-          auto state = id(fan_control_ud).state.c_str();
+          auto state = id(vanes_control_ud).state.c_str();
           ESP_LOGD("main", "Option of my select: %s", state);
           uint8_t vanesUD = 0;  // Initialize the vanesUD variable
-          if (id(fan_control_ud).state == "3D Auto") {
+          if (id(vanes_control_ud).state == "3D Auto") {
             id(fan_control_3Dauto).publish_state(true);
-          } else if (id(fan_control_ud).state == "Up") {
+          } else if (id(vanes_control_ud).state == "${up}") {
             vanesUD = 1;
-          } else if (id(fan_control_ud).state == "Up/Center") {
+          } else if (id(vanes_control_ud).state == "${up_center}") {
             vanesUD = 2;
-          } else if (id(fan_control_ud).state == "Center/Down") {
+          } else if (id(vanes_control_ud).state == "${center_down}") {
             vanesUD = 3;
-          } else if (id(fan_control_ud).state == "Down") {
+          } else if (id(vanes_control_ud).state == "${down}") {
             vanesUD = 4;
-          } else if (id(fan_control_ud).state == "Swing") {
+          } else if (id(vanes_control_ud).state == "${swing}") {
             vanesUD = 5;
           }
           if ((vanesUD > 0) & (vanesUD < 6) & (vanesUD != id(vanes_UD_received).state)){
@@ -349,20 +449,23 @@ select:
           else {
             ESP_LOGD("main", "Not setting vanesUD: %i", vanesUD);
           }
+    web_server:
+      sorting_group_id: Control
+      sorting_weight: 4
 
   - platform: template
     id: fan_speed
-    name: Fan speed
+    name: ${fan_speed}
     icon: mdi:fan
     entity_category: config
     optimistic: true
     internal: false  
     options:
-     - "Quiet"
-     - "Low"
-     - "Medium"
-     - "High"
-     - "Auto"
+     - "${quiet}"
+     - "${low}"
+     - "${medium}"
+     - "${high}"
+     - "${auto}"
     on_value:
       then:
         - climate.control:
@@ -379,13 +482,17 @@ select:
                 } else {
                   return CLIMATE_FAN_AUTO;
                 }
+    web_server:
+      sorting_group_id: Control
+      sorting_weight: 2
 
 switch:
   - platform: template
-    name: 3D Auto
+    name: ${d_auto}
     id: fan_control_3Dauto
     icon: mdi:video-3d
     optimistic: true
+    entity_category: config
     turn_on_action:
       - lambda: |-
           if (id(frame_size_sensor).state == 33) {
@@ -406,3 +513,6 @@ switch:
           } else {
             ESP_LOGD("main", "Frame size is not 33, cannot turn off 3DAuto");
           }
+    web_server:
+      sorting_group_id: Control
+      sorting_weight: 5

--- a/example.yaml
+++ b/example.yaml
@@ -134,7 +134,6 @@ sensor:
       - name: Return air temperature
       - name: Outdoor unit fan speed
       - name: Indoor unit fan speed
-        id: indoor_unit_fan_speed
       - name: Compressor current
         id: compressor_current
       - name: Compressor frequency
@@ -221,7 +220,6 @@ sensor:
     lambda: return id(compressor_current).state * 230;
 
   - platform: template
-    name: "Fan mode value"
     id: fan_mode_value
     entity_category: DIAGNOSTIC
     internal: true
@@ -232,20 +230,20 @@ sensor:
       } else {
           ESP_LOGD("main", "NEW value do something");
           if (new_value == 9.0) {
-            id(fan_speed).publish_state("${quiet}");
+            id(fan_speed).publish_state("Quiet");
           } else if (new_value == 3.0) {
-            id(fan_speed).publish_state("${low}");
+            id(fan_speed).publish_state("Low");
           } else if (new_value == 4.0) {
-            id(fan_speed).publish_state("${medium}");
+            id(fan_speed).publish_state("Medium");
           } else if (new_value == 5.0) {
-            id(fan_speed).publish_state("${high}");
+            id(fan_speed).publish_state("High");
           } else if (new_value == 2.0) {
-            id(fan_speed).publish_state("${auto}");
+            id(fan_speed).publish_state("Auto");
           }
           return new_value;  // Update the state with the new value
       }      
     update_interval: 30s
-    
+
 text_sensor:
   - platform: version
     name: ESPHome Version
@@ -360,11 +358,11 @@ select:
     optimistic: true
     internal: false  
     options:
-     - "${quiet}"
-     - "${low}"
-     - "${medium}"
-     - "${high}"
-     - "${auto}"
+     - "Quiet"
+     - "Low"
+     - "Medium"
+     - "High"
+     - "Auto"
     on_value:
       then:
         - climate.control:

--- a/example.yaml
+++ b/example.yaml
@@ -18,6 +18,24 @@ esphome:
     # Run CPU at 160Mhz to fix mhi_ac_ctrl_core.loop error: -2
     board_build.f_cpu: 160000000L
 
+external_components:
+  - source: github://fonske/MHI-AC-Ctrl-ESPHome@master
+    components: [ MhiAcCtrl ]
+
+## remote options
+packages:
+  remote_package:
+    url: https://github.com/fonske/MHI-AC-Ctrl-ESPHome/
+    ref: master
+    refresh: always
+    files: [ 
+            #confs/onewire.yml,
+            #confs/debug.yml,
+            confs/wifi-info.yml,
+            confs/labels-en.yml,
+            #confs/labels-nl.yml,
+           ]
+           
 esp8266:
   board: d1_mini
 
@@ -61,24 +79,6 @@ web_server:
     - id: Status
       name: "${status}"
       sorting_weight: -10
-
-external_components:
-  - source: github://fonske/MHI-AC-Ctrl-ESPHome@master
-    components: [ MhiAcCtrl ]
-
-## remote options
-packages:
-  remote_package:
-    url: https://github.com/fonske/MHI-AC-Ctrl-ESPHome/
-    ref: master
-    refresh: always
-    files: [ 
-            #confs/onewire.yml,
-            #confs/debug.yml,
-            confs/wifi-info.yml,
-            confs/labels-en.yml,
-            #confs/labels-nl.yml,
-           ]
 
 MhiAcCtrl:
   id: ${mhi_device_id}


### PR DESCRIPTION
Added the fan modes
Quiet, low, medium, high, auto in an extra dropdown menu so it is available through the webserver also.

Switching the mode directly from the Climate sensor- fan mode has a small time delay of 30 seconds on the dropdown menu value before it changes the value
Couldnt improve that much better.

But the change in fan_mode is direct.