### PR TITLE
Version 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ This will allow for lower temperature heating or cooling
 # Changelog:
 
 **v4.1** (2025-07)
- - Changed climate.CLIMATE_SCHEMA to fix deprecation warning in 2025.5.0 and higher #151
- - Make 0.5 degrees setpoint actually work #88
- - Allow low temp heating and cooling (below 18 degrees) #152
- - Allow fan speed from esphome web interface #136
+ - Changed climate.CLIMATE_SCHEMA to fix deprecation warning in 2025.5.0 and higher https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/151
+ - Make 0.5 degrees setpoint actually work https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/88
+ - Allow low temp heating and cooling (below 18 degrees) https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/152
+ - Allow fan speed from esphome web interface https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/136
 
 **v4.0** (2025-04)
  - Compatibility with ESPHOME 2025.2+

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ This will allow for lower temperature heating or cooling
 # Changelog:
 
 **v4.1** (2025-07)
- - Changed climate.CLIMATE_SCHEMA to fix deprecation warning in 2025.5.0 and higher 
- - Make 0.5 degrees setpoint actually work
- - Allow low temp heating and cooling (below 18 degrees)
+ - Changed climate.CLIMATE_SCHEMA to fix deprecation warning in 2025.5.0 and higher #151
+ - Make 0.5 degrees setpoint actually work #88
+ - Allow low temp heating and cooling (below 18 degrees) #152
+ - Allow fan speed from esphome web interface #136
 
 **v4.0** (2025-04)
  - Compatibility with ESPHOME 2025.2+

--- a/components/MhiAcCtrl/climate/__init__.py
+++ b/components/MhiAcCtrl/climate/__init__.py
@@ -7,7 +7,6 @@ from esphome.core import coroutine
 from esphome.const import (
     CONF_ID,
     CONF_ICON,
-    CONF_VISUAL_MIN_TEMPERATURE,
 )
 from .. import MhiAcCtrl, CONF_MHI_AC_CTRL_ID
 
@@ -15,6 +14,7 @@ mhi_ns = cg.esphome_ns.namespace('mhi')
 MhiClimate = mhi_ns.class_('MhiClimate', cg.Component, climate.Climate)
 
 CONF_TEMPERATURE_OFFSET = "temperature_offset"
+CONF_VISUAL_MIN_TEMPERATURE = "visual_min_temperature"
 
 CONFIG_SCHEMA = climate.climate_schema(MhiClimate).extend(
     {

--- a/components/MhiAcCtrl/climate/__init__.py
+++ b/components/MhiAcCtrl/climate/__init__.py
@@ -1,10 +1,13 @@
+# __init__.py
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import climate
 from esphome.core import coroutine
 from esphome.const import (
     CONF_ID,
-    CONF_ICON
+    CONF_ICON,
+    CONF_VISUAL_MIN_TEMPERATURE,
 )
 from .. import MhiAcCtrl, CONF_MHI_AC_CTRL_ID
 
@@ -18,8 +21,10 @@ CONFIG_SCHEMA = climate.climate_schema(MhiClimate).extend(
         cv.GenerateID(CONF_MHI_AC_CTRL_ID): cv.use_id(MhiAcCtrl),
         cv.Optional(CONF_ICON, default="mdi:air-conditioner"): cv.icon,
         cv.Optional(CONF_TEMPERATURE_OFFSET, default=False): cv.boolean,
+        cv.Optional(CONF_VISUAL_MIN_TEMPERATURE, default=18.0): cv.temperature,
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
 
 
 @coroutine
@@ -35,3 +40,6 @@ async def to_code(config):
     
     if config[CONF_TEMPERATURE_OFFSET]:
         cg.add(var.set_temperature_offset_enabled(True))
+
+    if CONF_VISUAL_MIN_TEMPERATURE in config:
+        cg.add(var.set_minimum_temperature(config[CONF_VISUAL_MIN_TEMPERATURE]))

--- a/components/MhiAcCtrl/climate/__init__.py
+++ b/components/MhiAcCtrl/climate/__init__.py
@@ -11,10 +11,13 @@ from .. import MhiAcCtrl, CONF_MHI_AC_CTRL_ID
 mhi_ns = cg.esphome_ns.namespace('mhi')
 MhiClimate = mhi_ns.class_('MhiClimate', cg.Component, climate.Climate)
 
+CONF_TEMPERATURE_OFFSET = "temperature_offset"
+
 CONFIG_SCHEMA = climate.climate_schema(MhiClimate).extend(
     {
         cv.GenerateID(CONF_MHI_AC_CTRL_ID): cv.use_id(MhiAcCtrl),
         cv.Optional(CONF_ICON, default="mdi:air-conditioner"): cv.icon,
+        cv.Optional(CONF_TEMPERATURE_OFFSET, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -29,3 +32,6 @@ async def to_code(config):
     
     if CONF_ICON in config:
         cg.add(var.set_icon(config[CONF_ICON]))
+    
+    if config[CONF_TEMPERATURE_OFFSET]:
+        cg.add(var.set_temperature_offset_enabled(True))

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -223,6 +223,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
             
             if (fractional_part >= 0.5) {
                 // For x.5 temperatures, set AC to x+1 and offset return temp by +0.5
+                ESP_LOGD(TAG, "Setting target temperature with offset: %f", ceil(target_temp));
                 this->platform_->set_tsetpoint(ceil(target_temp));
                 this->temperature_offset_ = 0.5;
             } else {

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -333,7 +333,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
     this->publish_state();
 }
 
-void MhiClimate::on_status_change(ACStatus status, int value) {
+void MhiClimate::update_status(ACStatus status, int value) {
     // ... existing status handling ...
     
     if (status == TROOM) {

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -194,11 +194,11 @@ void MhiClimate::update_status(ACStatus status, int value) {
         this->vanesLR_pos_state_ = value;
         break;
     case status_troom:
-        // dtostrf((value - 61) / 4.0, 0, 2, strtmp);
-        // output_P(status, PSTR(TOPIC_TROOM), strtmp);
-        this->current_temperature = (value - 61) / 4.0;
+        // Calculate the temperature and apply the offset for 0.5°C steps
+        this->current_temperature = ((value - 61) / 4.0) - this->temperature_offset_;
         this->publish_state();
         break;
+
     case status_tsetpoint:
         // itoa(value, strtmp, 10);
         // output_P(status, PSTR(TOPIC_TSETPOINT), strtmp);
@@ -333,16 +333,6 @@ void MhiClimate::control(const climate::ClimateCall& call) {
     this->publish_state();
 }
 
-void MhiClimate::update_status(ACStatus status, int value) {
-    // ... existing status handling ...
-    
-    if (status == TROOM) {
-        // Apply temperature offset to "fool" the AC unit
-        float adjusted_temp = value - this->temperature_offset_;
-        this->current_temperature = adjusted_temp;
-        this->publish_state();
-    }
-}
 
 /// Return the traits of this controller.
 climate::ClimateTraits MhiClimate::traits() {

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -274,16 +274,6 @@ void MhiClimate::control(const climate::ClimateCall& call) {
         this->platform_->set_mode(mode_);
     }
 
-    if (call.get_target_temperature().has_value()) {
-        this->target_temperature = *call.get_target_temperature();
-
-        ESP_LOGE(TAG, "TEMP: Set %f", this->target_temperature);
-
-        this->tsetpoint_ = clamp(this->target_temperature, minimum_temperature_, maximum_temperature_);
-
-        this->platform_->set_tsetpoint(this->tsetpoint_);
-    }
-
     if (call.get_fan_mode().has_value()) {
         this->fan_mode = *call.get_fan_mode();
 

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -48,6 +48,9 @@ public:
         this->temperature_offset_enabled_ = enabled; 
     }
 
+    void set_minimum_temperature(float temp) { 
+        this->minimum_temperature_ = temp; 
+    }
 };
 
 }

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -25,6 +25,8 @@ protected:
     void update_status(ACStatus status, int value) override;
 
 private:
+    bool temperature_offset_enabled_{false};
+    float temperature_offset_{0.0};
     float minimum_temperature_{18.0f};
     float maximum_temperature_{30.0f};
     float temperature_step_{0.5f};
@@ -40,6 +42,11 @@ private:
     int vanes_pos_old_state_;
     int vanes_pos_state_;
     MhiPlatform* platform_;
+
+public:
+    void set_temperature_offset_enabled(bool enabled) { 
+        this->temperature_offset_enabled_ = enabled; 
+    }
 
 };
 

--- a/components/MhiAcCtrl/select/__init__.py
+++ b/components/MhiAcCtrl/select/__init__.py
@@ -11,6 +11,7 @@ CONF_VERTICAL_SELECTS = [
     "Down",
     "Swing",
 ]
+ICON_UP_DOWN = "mdi:arrow-up-down"
 CONF_HORIZONTAL = "horizontal_vanes"
 CONF_HORIZONTAL_SELECTS = [
     "Left",
@@ -23,14 +24,24 @@ CONF_HORIZONTAL_SELECTS = [
     "Swing",
 ]
 ICON_LEFT_RIGHT = "mdi:arrow-left-right"
-ICON_UP_DOWN = "mdi:arrow-up-down"
+
+CONF_FAN_SPEED = "fan_speed"
+CONF_FAN_SPEED_SELECTS = [
+    "Auto",
+    "Quiet",
+    "Low",
+    "Medium",
+    "High",
+]
+ICON_FAN = "mdi:fan"
+
 
 mhi_ns = cg.esphome_ns.namespace('mhi')
 MhiVerticalVanesSelect = mhi_ns.class_("MhiVerticalVanesSelect", cg.Component)
 MhiHorizontalVanesSelect = mhi_ns.class_("MhiHorizontalVanesSelect", cg.Component)
+MhiFanSpeedSelect = mhi_ns.class_("MhiFanSpeedSelect", cg.Component)
 
 CONFIG_SCHEMA = {
-    
     cv.GenerateID(CONF_MHI_AC_CTRL_ID): cv.use_id(MhiAcCtrl),
     cv.Optional(CONF_VERTICAL): select.select_schema(
         MhiVerticalVanesSelect,
@@ -40,16 +51,19 @@ CONFIG_SCHEMA = {
         MhiHorizontalVanesSelect,
         icon=ICON_LEFT_RIGHT
     ),
+    cv.Optional(CONF_FAN_SPEED): select.select_schema(
+        MhiFanSpeedSelect,
+        icon=ICON_FAN
+    ),
 }
 
 
 async def to_code(config):
-    
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
     if vertical_config := config.get(CONF_VERTICAL):
         sel = await select.new_select(
             vertical_config,
-            options=[CONF_VERTICAL_SELECTS],
+            options=CONF_VERTICAL_SELECTS,
         )
         await cg.register_parented(sel, mhi)
         await cg.register_component(sel, vertical_config)
@@ -57,7 +71,15 @@ async def to_code(config):
     if horizontal_config := config.get(CONF_HORIZONTAL):
         sel = await select.new_select(
             horizontal_config,
-            options=[CONF_HORIZONTAL_SELECTS],
+            options=CONF_HORIZONTAL_SELECTS,
         )
         await cg.register_parented(sel, mhi)
         await cg.register_component(sel, horizontal_config)
+
+    if fan_speed_config := config.get(CONF_FAN_SPEED):
+        sel = await select.new_select(
+            fan_speed_config,
+            options=CONF_FAN_SPEED_SELECTS,
+        )
+        await cg.register_parented(sel, mhi)
+        await cg.register_component(sel, fan_speed_config)

--- a/components/MhiAcCtrl/select/mhi_fan_speed_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_fan_speed_select.cpp
@@ -1,0 +1,49 @@
+#include "esphome/core/log.h"
+#include "mhi_fan_speed_select.h"
+
+namespace esphome {
+namespace mhi {
+
+static const char *const TAG = "mhi.select";
+
+void MhiFanSpeedSelect::setup() {
+    this->parent_->add_listener(this);
+}
+
+void MhiFanSpeedSelect::dump_config(){
+    ESP_LOGCONFIG(TAG, "MHI Fan Speed Select");
+}
+
+void MhiFanSpeedSelect::control(const std::string &value) {
+    int fan_code = 7; // Default to Auto
+    if (value == "Quiet") {
+        fan_code = 0;
+    } else if (value == "Low") {
+        fan_code = 1;
+    } else if (value == "Medium") {
+        fan_code = 2;
+    } else if (value == "High") {
+        fan_code = 6;
+    }
+    
+    this->parent_->set_fan(fan_code);
+    this->publish_state(value);
+}
+
+void MhiFanSpeedSelect::update_status(ACStatus status, int value) {
+    if (status == status_fan) {
+        std::string fan_mode_str = "Auto";
+        switch (value) {
+            case 0: fan_mode_str = "Quiet"; break;
+            case 1: fan_mode_str = "Low"; break;
+            case 2: fan_mode_str = "Medium"; break;
+            case 6: fan_mode_str = "High"; break;
+            case 7: fan_mode_str = "Auto"; break;
+        }
+        this->publish_state(fan_mode_str);
+        ESP_LOGD(TAG, "Fan speed status updated to: %s", fan_mode_str.c_str());
+    }
+}
+
+}  // namespace mhi
+}  // namespace esphome

--- a/components/MhiAcCtrl/select/mhi_fan_speed_select.h
+++ b/components/MhiAcCtrl/select/mhi_fan_speed_select.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "../mhi_platform.h"
+
+namespace esphome {
+namespace mhi {
+
+class MhiFanSpeedSelect : 
+    public Component, 
+    public select::Select, 
+    public Parented<MhiPlatform>,
+    protected MhiStatusListener {
+public:
+    MhiFanSpeedSelect() = default;
+
+protected:
+    void control(const std::string &value) override;
+    void setup() override;
+    void dump_config() override;
+    void update_status(ACStatus status, int value) override;
+};
+
+}
+}

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -76,6 +76,7 @@ button:
 climate:
   - platform: MhiAcCtrl
     name: "MHI Air Conditioner"
+    temperature_offset: true
     visual:
       temperature_step:
         target_temperature: 0.5

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -77,6 +77,7 @@ climate:
   - platform: MhiAcCtrl
     name: "MHI Air Conditioner"
     temperature_offset: true
+    visual_min_temperature: 17.0
     visual:
       temperature_step:
         target_temperature: 0.5

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -162,6 +162,8 @@ select:
       name: Fan Control Up Down
     horizontal_vanes:
       name: Fan Control Left Right
+    fan_speed:
+      name: "Fan Speed"
 
 switch:
   - platform: MhiAcCtrl


### PR DESCRIPTION
**v4.1** (2025-07)
 - Changed climate.CLIMATE_SCHEMA to fix deprecation warning in 2025.5.0 and higher https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/151
 - Make 0.5 degrees setpoint actually work https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/88
 - Allow low temp heating and cooling (below 18 degrees) https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/152
 - Allow fan speed from esphome web interface https://github.com/ginkage/MHI-AC-Ctrl-ESPHome/issues/136


closes ginkage/#88, closes ginkage/#136, closes ginkage/#151, closes ginkage/#152