### PR TITLE
Configurable pins

### DIFF
--- a/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
+++ b/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
@@ -54,9 +54,9 @@ void MHI_AC_Ctrl_Core::reset_old_values() {  // used e.g. when MQTT connection t
 
 void MHI_AC_Ctrl_Core::init() {
   //MeasureFrequency(m_cbiStatus);
-  pinMode(SCK_PIN, INPUT);
-  pinMode(MOSI_PIN, INPUT);
-  pinMode(MISO_PIN, OUTPUT);
+  pinMode(sck_pin_, INPUT);
+  pinMode(mosi_pin_, INPUT);
+  pinMode(miso_pin_, OUTPUT);
   MHI_AC_Ctrl_Core::reset_old_values();
 }
 
@@ -144,7 +144,7 @@ static byte MOSI_frame[33];
   call_counter++;
   int SCKMillis = millis();               // time of last SCK low level
   while (millis() - SCKMillis < 5) {      // wait for 5ms stable high signal to detect a frame start
-    if (!digitalRead(SCK_PIN))
+    if (!digitalRead(sck_pin_))
       SCKMillis = millis();
     if (millis() - startMillis > max_time_ms)
       return err_msg_timeout_SCK_low;       // SCK stuck@ low error detection
@@ -242,16 +242,16 @@ static byte MOSI_frame[33];
     byte bit_mask = 1;
     for (uint8_t bit_cnt = 0; bit_cnt < 8; bit_cnt++) { // read and write 1 byte
       SCKMillis = millis();
-      while (digitalRead(SCK_PIN)) { // wait for falling edge
+      while (digitalRead(sck_pin_)) { // wait for falling edge
         if (millis() - startMillis > max_time_ms)
           return err_msg_timeout_SCK_high;       // SCK stuck@ high error detection
       } 
       if ((MISO_frame[byte_cnt] & bit_mask) > 0)
-        digitalWrite(MISO_PIN, 1);
+        digitalWrite(miso_pin_, 1);
       else
-        digitalWrite(MISO_PIN, 0);
-      while (!digitalRead(SCK_PIN)) {} // wait for rising edge
-      if (digitalRead(MOSI_PIN))
+        digitalWrite(miso_pin_, 0);
+      while (!digitalRead(sck_pin_)) {} // wait for rising edge
+      if (digitalRead(mosi_pin_))
         MOSI_byte += bit_mask;
       bit_mask = bit_mask << 1;
     }

--- a/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
+++ b/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
@@ -31,11 +31,6 @@ const byte opdata[][2] PROGMEM = {
 #define NoFramesPerOpDataCycle 400             // number of frames used for a OpData request cycle; will be 20s (20 frames are 1s)
 #define minTimeInternalTroom 5000              // minimal time in ms used for Troom internal sensor changes for publishing to avoid jitter 
 
-// pin defintions
-#define SCK_PIN  14
-#define MOSI_PIN 13
-#define MISO_PIN 12
-
 // constants for the frame
 #define SB0 0
 #define SB1 SB0 + 1
@@ -113,6 +108,11 @@ class CallbackInterface_Status {
 
 class MHI_AC_Ctrl_Core {
   private:
+    // pins
+    const uint8_t sck_pin_;
+    const uint8_t mosi_pin_;
+    const uint8_t miso_pin_;
+
     // old status
     byte status_power_old;
     byte status_mode_old;
@@ -166,6 +166,8 @@ class MHI_AC_Ctrl_Core {
     CallbackInterface_Status *m_cbiStatus;
 
   public:
+    explicit MHI_AC_Ctrl_Core(const uint8_t sck_pin, const uint8_t mosi_pin, const uint8_t miso_pin) : sck_pin_(sck_pin), mosi_pin_(mosi_pin), miso_pin_(miso_pin) {}
+
     void MHIAcCtrlStatus(CallbackInterface_Status *cb) {
       m_cbiStatus = cb;
     };

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -5,6 +5,9 @@ from esphome.components import sensor
 from esphome.const import CONF_ID
 
 CONF_MHI_AC_CTRL_ID = "mhi_ac_ctrl_id"
+CONF_SCK_PIN = 'sck_pin'
+CONF_MOSI_PIN = 'mosi_pin'
+CONF_MISO_PIN = 'miso_pin'
 CONF_FRAME_SIZE = 'frame_size'
 CONF_ROOM_TEMP_TIMEOUT = 'room_temp_timeout'
 CONF_VANES_UD = 'initial_vertical_vanes_position'
@@ -23,6 +26,9 @@ SetExternalRoomTemperatureAction = mhi_ns.class_("SetExternalRoomTemperatureActi
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(MhiAcCtrl),
+    cv.Optional(CONF_SCK_PIN, default = 14):  cv.uint16_t,
+    cv.Optional(CONF_MOSI_PIN, default = 13): cv.uint16_t,
+    cv.Optional(CONF_MISO_PIN, default = 12): cv.uint16_t,
     cv.Optional(CONF_EXTERNAL_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
     cv.Optional(CONF_FRAME_SIZE, default=20): cv.int_range(min=20, max=33),
     cv.Optional(CONF_ROOM_TEMP_TIMEOUT, default=60): cv.int_range(min=0, max=3600),
@@ -31,7 +37,10 @@ CONFIG_SCHEMA = cv.Schema({
 }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = cg.new_Pvariable(config[CONF_ID],
+                           config[CONF_SCK_PIN],
+                           config[CONF_MOSI_PIN],
+                           config[CONF_MISO_PIN])
     await cg.register_component(var, config)
     cg.add(var.set_frame_size(config[CONF_FRAME_SIZE]))
     cg.add(var.set_room_temp_api_timeout(config[CONF_ROOM_TEMP_TIMEOUT]))

--- a/components/MhiAcCtrl/mhi_platform.h
+++ b/components/MhiAcCtrl/mhi_platform.h
@@ -48,7 +48,7 @@ private:
 
     MHI_AC_Ctrl_Core mhi_ac_ctrl_core_;
 
-    sensor::Sensor* external_temperature_sensor_;
+    sensor::Sensor* external_temperature_sensor_{nullptr};
 
     std::vector<MhiStatusListener*> listeners_;
 };

--- a/components/MhiAcCtrl/mhi_platform.h
+++ b/components/MhiAcCtrl/mhi_platform.h
@@ -16,6 +16,7 @@ class MhiPlatform :
     public CallbackInterface_Status {
 
 public:
+    MhiPlatform(uint8_t sck_pin, uint8_t mosi_pin, uint8_t miso_pin) : mhi_ac_ctrl_core_(sck_pin, mosi_pin, miso_pin) {}
 
     void setup() override;
     void set_frame_size(int framesize);


### PR DESCRIPTION
This PR replaces the hardcoded values for used pin definitions with configurable ones. (By default these new pin configurations are set to their original hardcoded values)

Resolves #129, related to #43.

With the following config I've been able to use an esp32_d1_mini as a drop in replacement for the esp8266 D1 mini using the same shield that connects it to the A/C header:

```yaml

...

esp32:
  board: wemos_d1_mini32

MhiAcCtrl:
  frame_size: 33
  sck_pin: 18
  miso_pin: 19
  mosi_pin: 23

...

```