### PR TITLE
Fix select controls not inheriting from select::Select

### DIFF
--- a/components/MhiAcCtrl/select/__init__.py
+++ b/components/MhiAcCtrl/select/__init__.py
@@ -37,9 +37,9 @@ ICON_FAN = "mdi:fan"
 
 
 mhi_ns = cg.esphome_ns.namespace('mhi')
-MhiVerticalVanesSelect = mhi_ns.class_("MhiVerticalVanesSelect", cg.Component)
-MhiHorizontalVanesSelect = mhi_ns.class_("MhiHorizontalVanesSelect", cg.Component)
-MhiFanSpeedSelect = mhi_ns.class_("MhiFanSpeedSelect", cg.Component)
+MhiVerticalVanesSelect = mhi_ns.class_("MhiVerticalVanesSelect", select.Select, cg.Component)
+MhiHorizontalVanesSelect = mhi_ns.class_("MhiHorizontalVanesSelect", select.Select, cg.Component)
+MhiFanSpeedSelect = mhi_ns.class_("MhiFanSpeedSelect", select.Select, cg.Component)
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_MHI_AC_CTRL_ID): cv.use_id(MhiAcCtrl),


### PR DESCRIPTION
Trying to use the action

```
      - select.set:
          id: vertical_vanes_control
          option: "Up"
```

Resulted in the error:

```
      - select.set:
          ID 'vertical_vanes_control' of type mhi::MhiVerticalVanesSelect doesn't inherit from select::Select. Please double check your ID is pointing to the correct value.
```