### PR TITLE
Add pin validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,146 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Hide sublime text stuff
+*.sublime-project
+*.sublime-workspace
+
+# Intellij Idea
+.idea
+
+# Eclipse
+.project
+.cproject
+.pydevproject
+.settings/
+
+# Vim
+*.swp
+
+# Hide some OS X stuff
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
+# Thumbnails
+._*
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.esphome
+nosetests.xml
+coverage.xml
+cov.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# pyenv
+.python-version
+
+# asdf
+.tool-versions
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+venv-*/
+
+# mypy
+.mypy_cache/
+
+.pioenvs
+.piolibdeps
+.pio
+.vscode/
+!.vscode/tasks.json
+CMakeListsPrivate.txt
+CMakeLists.txt
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/dynamic.xml
+
+# CMake
+cmake-build-*/
+
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+/*.cbp
+
+.clang_complete
+.gcc-flags.json
+
+config/
+tests/build/
+tests/.esphome/
+/.temp-clang-tidy.cpp
+/.temp/
+.pio/
+
+sdkconfig.*
+!sdkconfig.defaults
+
+.tests/
+
+/components
+/managed_components
+
+api-docs/

--- a/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
+++ b/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include "esphome/core/hal.h"
 
 // comment out the data you are not interested, but at least leave one row !
 const byte opdata[][2] PROGMEM = {
@@ -29,13 +30,7 @@ const byte opdata[][2] PROGMEM = {
 
 //#define NoFramesPerPacket 20                 // number of frames/packet, must be an even number
 #define NoFramesPerOpDataCycle 400             // number of frames used for a OpData request cycle; will be 20s (20 frames are 1s)
-#define minTimeInternalTroom 5000              // minimal time in ms used for Troom internal sensor changes for publishing to avoid jitter 
-
-// Declare extern variables for the pins the only change to the original code
-// This allows to set the pins in the configuration file
-extern int SCK_PIN;
-extern int MOSI_PIN;
-extern int MISO_PIN;
+#define minTimeInternalTroom 5000              // minimal time in ms used for Troom internal sensor changes for publishing to avoid jitter
 
 // constants for the frame
 #define SB0 0
@@ -158,7 +153,7 @@ class MHI_AC_Ctrl_Core {
     bool request_erropData = false;
     byte new_Troom = 0xff;    // writing 0xff to DB3 indicates the usage of the internal room temperature sensor
     float Troom_offset = 0.0;
-    
+
     byte new_VanesLR0 = 0;
     byte new_VanesLR1 = 0;
     byte new_3Dauto = 0;
@@ -166,13 +161,17 @@ class MHI_AC_Ctrl_Core {
 
     CallbackInterface_Status *m_cbiStatus;
 
+    esphome::GPIOPin * sck_pin_;
+    esphome::GPIOPin * mosi_pin_;
+    esphome::GPIOPin * miso_pin_;
+
   public:
     void MHIAcCtrlStatus(CallbackInterface_Status *cb) {
       m_cbiStatus = cb;
     };
 
 
-    void init();                          // initialization called once after boot
+    void init(esphome::GPIOPin * sck_pin, esphome::GPIOPin * mosi_pin, esphome::GPIOPin * miso_pin);                          // initialization called once after boot
     void reset_old_values();              // resets the 'old' variables ensuring that all status information are resend
     int loop(uint max_time_ms);           // receive / transmit a frame of 20 bytes
     void set_power(boolean power);        // power on/off the AC

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import automation
+from esphome import automation, pins
 from esphome.components import sensor
 from esphome.const import CONF_ID
 
@@ -31,9 +31,9 @@ CONFIG_SCHEMA = cv.Schema({
     cv.Optional(CONF_ROOM_TEMP_TIMEOUT, default=60): cv.int_range(min=0, max=3600),
     cv.Optional(CONF_VANES_UD): cv.int_range(min=0, max=5),
     cv.Optional(CONF_VANES_LR): cv.int_range(min=0, max=8),
-    cv.Optional(CONF_SCK_PIN): cv.int_,
-    cv.Optional(CONF_MOSI_PIN): cv.int_,
-    cv.Optional(CONF_MISO_PIN): cv.int_,
+    cv.Optional(CONF_SCK_PIN, default="14"): pins.gpio_input_pin_schema,
+    cv.Optional(CONF_MOSI_PIN, default="13"): pins.gpio_input_pin_schema,
+    cv.Optional(CONF_MISO_PIN, default="12"): pins.gpio_output_pin_schema,
 }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
@@ -48,12 +48,13 @@ async def to_code(config):
         cg.add(var.set_vanes(config[CONF_VANES_UD]))
     if CONF_VANES_LR in config:
         cg.add(var.set_vanesLR(config[CONF_VANES_LR]))
-    if CONF_SCK_PIN in config:
-        cg.add(var.set_sck_pin(config[CONF_SCK_PIN]))
-    if CONF_MOSI_PIN in config:
-        cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
-    if CONF_MISO_PIN in config:
-        cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
+
+    sck = await cg.gpio_pin_expression(config[CONF_SCK_PIN])
+    mosi = await cg.gpio_pin_expression(config[CONF_MOSI_PIN])
+    miso = await cg.gpio_pin_expression(config[CONF_MISO_PIN])
+    cg.add(var.set_sck_pin(sck))
+    cg.add(var.set_mosi_pin(mosi))
+    cg.add(var.set_miso_pin(miso))
 
 @automation.register_action(
     "climate.mhi.set_vertical_vanes",

--- a/components/MhiAcCtrl/mhi_platform.cpp
+++ b/components/MhiAcCtrl/mhi_platform.cpp
@@ -1,8 +1,5 @@
 #include "mhi_platform.h"
 
-int SCK_PIN = 14;
-int MOSI_PIN = 13;
-int MISO_PIN = 12;
 namespace esphome {
 namespace mhi {
 
@@ -10,23 +7,12 @@ static const char* TAG = "mhi.platform";
 
 
 void MhiPlatform::setup() {
-    
-    if (this->sck_pin_ >= 0) { //
-      SCK_PIN = this->sck_pin_;
-    }
-    if (this->mosi_pin_ >= 0) { //
-      MOSI_PIN = this->mosi_pin_;
-    }
-    if (this->miso_pin_ >= 0) { //
-      MISO_PIN = this->miso_pin_;
-    }
-
     this->mhi_ac_ctrl_core_.MHIAcCtrlStatus(this);
-    this->mhi_ac_ctrl_core_.init();
+    this->mhi_ac_ctrl_core_.init(this->sck_pin_, this->mosi_pin_, this->miso_pin_); // initialize MHI AC Ctrl core
     this->mhi_ac_ctrl_core_.set_frame_size(this->frame_size_); // set framesize. Only 20 (legacy) or 33 (includes 3D auto and vertical vanes) possible
 
     if (this->external_temperature_sensor_ != nullptr) {
-        this->external_temperature_sensor_->add_on_state_callback([this](float state) {        
+        this->external_temperature_sensor_->add_on_state_callback([this](float state) {
             this->transfer_room_temperature(state);
         });
         this->transfer_room_temperature(this->external_temperature_sensor_->state);
@@ -123,12 +109,12 @@ void MhiPlatform::set_mode(ACMode value){
 }
 void MhiPlatform::set_tsetpoint(float value) {
     this->mhi_ac_ctrl_core_.set_tsetpoint((byte)(2 * value));
-    
+
     ESP_LOGD(TAG, "set setpoint: %f", value);
 }
 
 void MhiPlatform::set_vanes(int value) {
-    
+
     this->mhi_ac_ctrl_core_.set_vanes(value);
     ESP_LOGD(TAG, "set vanes: %i", value);
 }
@@ -136,7 +122,7 @@ void MhiPlatform::set_vanes(int value) {
 void MhiPlatform::set_vanesLR(int value) {
 
     if (this->frame_size_ == 33) {
-    
+
         ESP_LOGD(TAG, "setting vanesLR to: %i", value);
         this->mhi_ac_ctrl_core_.set_vanesLR(value);
         ESP_LOGD(TAG, "set vanes Left Right: %i", value);
@@ -148,7 +134,7 @@ void MhiPlatform::set_vanesLR(int value) {
 
 void MhiPlatform::set_3Dauto(bool value) {
     if (this->frame_size_ == 33) {
-        
+
         if (value) {
             ESP_LOGD(TAG, "set 3D auto: on");
             this->mhi_ac_ctrl_core_.set_3Dauto(AC3Dauto::Dauto_on); // Set swing to 3Dauto

--- a/components/MhiAcCtrl/mhi_platform.h
+++ b/components/MhiAcCtrl/mhi_platform.h
@@ -3,6 +3,7 @@
 
 #include "MHI-AC-Ctrl-core.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/time.h"
 #include <vector>
 #include <string>
@@ -11,11 +12,15 @@
 namespace esphome {
 namespace mhi {
 
-class MhiPlatform : 
-    public Component, 
+class MhiPlatform :
+    public Component,
     public CallbackInterface_Status {
 
 public:
+
+    void set_sck_pin(GPIOPin *sck_pin) { sck_pin_ = sck_pin; }
+    void set_mosi_pin(GPIOPin *mosi_pin) { mosi_pin_ = mosi_pin; }
+    void set_miso_pin(GPIOPin *miso_pin) { miso_pin_ = miso_pin; }
 
     void setup() override;
     void set_frame_size(int framesize);
@@ -25,7 +30,7 @@ public:
     void cbiStatusFunction(ACStatus status, int value) override;
 
     void set_room_temperature(float value);
-    
+
     void set_power(ACPower value);
     void set_fan(int value);
     void set_mode(ACMode value);
@@ -34,23 +39,20 @@ public:
     void set_vanesLR(int value);
     void set_3Dauto(bool value);
     void set_external_room_temperature_sensor(sensor::Sensor* sensor);
-    void set_sck_pin(int pin) { this->sck_pin_ = pin; };
-    void set_mosi_pin(int pin) { this->mosi_pin_ = pin; };
-    void set_miso_pin(int pin) { this->miso_pin_ = pin; };
     void add_listener(MhiStatusListener* listener);
 
 
 private:
     void transfer_room_temperature(float value);
-    float last_room_temperature_ = NAN; 
+    float last_room_temperature_ = NAN;
 
     int frame_size_;
     unsigned long room_temp_api_timeout_start_ = millis();
     unsigned long room_temp_api_timeout_;
     bool room_temp_api_active_ = false;
-    int sck_pin_ = -1;
-    int mosi_pin_ = -1;
-    int miso_pin_ = -1;
+    GPIOPin * sck_pin_;
+    GPIOPin * mosi_pin_;
+    GPIOPin * miso_pin_;
 
     MHI_AC_Ctrl_Core mhi_ac_ctrl_core_;
 


### PR DESCRIPTION
I made a mistake while configuring this component with the pin. The mistake was obvious and could have been avoid if the pin selection was using the ESPHome pin representation that checks the pin for the selected board. This PR does replace the int representation of a pin with a stronger type from ESPHome.