### PR TITLE
Fix breaking changes in ESPHome 2025.11

### DIFF
--- a/components/MhiAcCtrl/automation.h
+++ b/components/MhiAcCtrl/automation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/automation.h"
+#include "esphome/core/version.h"
 #include "mhi_platform.h"
 
 namespace esphome {
@@ -11,12 +12,18 @@ public:
   SetVerticalVanesAction(MhiPlatform *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(int, position);
   
-  void play(Ts... x) {
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override
+#else
+  void play(Ts... x) override
+#endif
+  {
     int pos = this->position_.value(x...);
     if (pos > 0 && pos < 6) {    
       this->parent_->set_vanes(pos);
     }    
   }
+
 protected:
   MhiPlatform *parent_;
 };
@@ -27,13 +34,18 @@ public:
   SetHorizontalVanesAction(MhiPlatform *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(int, position);
   
-  void play(Ts... x) {
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override
+#else
+  void play(Ts... x) override
+#endif
+  {
     int pos = this->position_.value(x...);
     if (pos > 0 && pos < 9) {    
       this->parent_->set_vanesLR(pos);
-    }  
-    
+    }
   }
+  
 protected:
   MhiPlatform *parent_;
 };
@@ -43,11 +55,18 @@ public:
   SetExternalRoomTemperatureAction(MhiPlatform *parent) : parent_(parent) {}
   TEMPLATABLE_VALUE(float, temperature);
   
-  void play(Ts... x) {
+  
+
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+  void play(const Ts&... x) override
+#else
+  void play(Ts... x) override
+#endif
+  {
     float temp = this->temperature_.value(x...);
-    this->parent_->set_room_temperature(temp);
-    
+    this->parent_->set_room_temperature(temp);    
   }
+
 protected:
   MhiPlatform *parent_;
 };

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -1,4 +1,5 @@
 #include "esphome/core/log.h"
+#include "esphome/core/version.h"
 #include "mhi_climate.h"
 
 namespace esphome {
@@ -342,6 +343,19 @@ void MhiClimate::control(const climate::ClimateCall& call) {
 
 
 /// Return the traits of this controller.
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
+climate::ClimateTraits MhiClimate::traits() {
+    auto traits = climate::ClimateTraits();
+    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY,climate::CLIMATE_MODE_FAN_ONLY });
+    traits.set_visual_min_temperature(this->minimum_temperature_);
+    traits.set_visual_max_temperature(this->maximum_temperature_);
+    traits.set_visual_temperature_step(this->temperature_step_);
+    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
+    traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
+    return traits;
+}
+#else
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.set_supports_current_temperature(true);
@@ -354,6 +368,7 @@ climate::ClimateTraits MhiClimate::traits() {
     traits.set_supported_swing_modes({ CLIMATE_SWING_OFF, CLIMATE_SWING_BOTH, CLIMATE_SWING_VERTICAL, CLIMATE_SWING_HORIZONTAL });
     return traits;
 }
+#endif
 
 
 } //namespace mhi

--- a/components/MhiAcCtrl/select/mhi_horizontal_vanes_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_horizontal_vanes_select.cpp
@@ -12,7 +12,7 @@ void MhiHorizontalVanesSelect::setup() {
 
 void MhiHorizontalVanesSelect::dump_config(){
     ESP_LOGCONFIG(TAG, "MHI Horizontal Vanes Select");
-    ESP_LOGCONFIG(TAG, "  state: %d", this->state);
+    ESP_LOGCONFIG(TAG, "  state: %d", this->current_option());
 }
 
 void MhiHorizontalVanesSelect::control(const std::string &value) {

--- a/components/MhiAcCtrl/select/mhi_vertical_vanes_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_vertical_vanes_select.cpp
@@ -12,7 +12,7 @@ void MhiVerticalVanesSelect::setup() {
 
 void MhiVerticalVanesSelect::dump_config(){
     ESP_LOGCONFIG(TAG, "MHI Vertical Vanes Select");
-    ESP_LOGCONFIG(TAG, "  state: %d", this->state);
+    ESP_LOGCONFIG(TAG, "  state: %d", this->current_option());
 }
 
 void MhiVerticalVanesSelect::control(const std::string &value) {


### PR DESCRIPTION
Addresses the changes required for ESPHome 2025.11.

https://developers.esphome.io/blog/2025/11/06/action-framework-performance-optimization/
https://developers.esphome.io/blog/2025/11/07/climate-entity-class-finitesetmask-and-flash-storage-optimizations/

Fixes #185

