### PR TITLE
Fix compatibility for ESPHome 2026.3.0 and add smart vane logic

### DIFF
--- a/.github/workflows/esphome-compatibility.yml
+++ b/.github/workflows/esphome-compatibility.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
-          cache: pip
+          python-version: "3.12"
 
       - name: Install ESPHome 2026.4.5
         run: python -m pip install "esphome==2026.4.5"

--- a/.github/workflows/esphome-compatibility.yml
+++ b/.github/workflows/esphome-compatibility.yml
@@ -1,0 +1,31 @@
+name: ESPHome compatibility
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  d1-mini-esphome-2026-4-5:
+    name: D1 mini / ESPHome 2026.4.5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install ESPHome 2026.4.5
+        run: python -m pip install "esphome==2026.4.5"
+
+      - name: Validate D1 mini fixture
+        run: esphome config tests/fixtures/mhi-srk25zsxw-d1-mini-2026.4.5.yaml
+
+      - name: Compile D1 mini fixture
+        run: esphome compile tests/fixtures/mhi-srk25zsxw-d1-mini-2026.4.5.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Python / ESPHome local artifacts
+__pycache__/
+*.py[cod]
+.esphome/
+build/
+secrets.yaml

--- a/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
+++ b/components/MhiAcCtrl/MHI-AC-Ctrl-core.h
@@ -97,11 +97,11 @@ enum ACMode {   // Mode enum
 };
 
 enum ACVanes {  // Vanes enum
-  vanes_1 = 1, vanes_2 = 2, vanes_3 = 3, vanes_4 = 4, vanes_unknown = 0, vanes_swing = 5
+  vanes_1 = 1, vanes_2 = 2, vanes_3 = 3, vanes_4 = 4, vanes_5 = 5, vanes_unknown = 0, vanes_swing = 6
 };
 
 enum ACVanesLR {  // Vanes Left Right enum
-  vanesLR_1 = 1, vanesLR_2 = 2, vanesLR_3 = 3, vanesLR_4 = 4, vanesLR_5 = 5, vanesLR_6 = 6, vanesLR_7 = 7, vanesLR_swing = 8
+  vanesLR_stop = 0, vanesLR_1 = 1, vanesLR_2 = 2, vanesLR_3 = 3, vanesLR_4 = 4, vanesLR_5 = 5, vanesLR_6 = 6, vanesLR_7 = 7, vanesLR_swing = 8
 };
 
 enum AC3Dauto {  // 3D auto enum
@@ -162,7 +162,7 @@ class MHI_AC_Ctrl_Core {
     byte new_VanesLR0 = 0;
     byte new_VanesLR1 = 0;
     byte new_3Dauto = 0;
-    byte frameSize = 20;
+    byte frameSize = 33;
 
     CallbackInterface_Status *m_cbiStatus;
 

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -1,60 +1,4 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
-from esphome import automation
-from esphome.components import sensor
-from esphome.const import CONF_ID
-
-CONF_MHI_AC_CTRL_ID = "mhi_ac_ctrl_id"
-CONF_FRAME_SIZE = 'frame_size'
-CONF_ROOM_TEMP_TIMEOUT = 'room_temp_timeout'
-CONF_VANES_UD = 'initial_vertical_vanes_position'
-CONF_VANES_LR = 'initial_horizontal_vanes_position'
-CONF_SCK_PIN = "sck_pin"
-CONF_MOSI_PIN = "mosi_pin"
-CONF_MISO_PIN = "miso_pin"
-
-CONF_VANES_POSITION = 'position'
-CONF_TEMPERATURE = 'temperature'
-CONF_EXTERNAL_TEMPERATURE_SENSOR = 'external_temperature_sensor'
-
-mhi_ns = cg.esphome_ns.namespace('mhi')
-MhiAcCtrl = mhi_ns.class_('MhiPlatform', cg.Component)
-
-SetVerticalVanesAction = mhi_ns.class_("SetVerticalVanesAction", automation.Action)
-SetHorizontalVanesAction = mhi_ns.class_("SetHorizontalVanesAction", automation.Action)
-SetExternalRoomTemperatureAction = mhi_ns.class_("SetExternalRoomTemperatureAction", automation.Action)
-
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(MhiAcCtrl),
-    cv.Optional(CONF_EXTERNAL_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
-    cv.Optional(CONF_FRAME_SIZE, default=20): cv.int_range(min=20, max=33),
-    cv.Optional(CONF_ROOM_TEMP_TIMEOUT, default=60): cv.int_range(min=0, max=3600),
-    cv.Optional(CONF_VANES_UD): cv.int_range(min=0, max=5),
-    cv.Optional(CONF_VANES_LR): cv.int_range(min=0, max=8),
-    cv.Optional(CONF_SCK_PIN): cv.int_,
-    cv.Optional(CONF_MOSI_PIN): cv.int_,
-    cv.Optional(CONF_MISO_PIN): cv.int_,
-}).extend(cv.COMPONENT_SCHEMA)
-
-async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
-    cg.add(var.set_frame_size(config[CONF_FRAME_SIZE]))
-    cg.add(var.set_room_temp_api_timeout(config[CONF_ROOM_TEMP_TIMEOUT]))
-    if CONF_EXTERNAL_TEMPERATURE_SENSOR in config:
-        sens = await cg.get_variable(config[CONF_EXTERNAL_TEMPERATURE_SENSOR])
-        cg.add(var.set_external_room_temperature_sensor(sens))
-    if CONF_VANES_UD in config:
-        cg.add(var.set_vanes(config[CONF_VANES_UD]))
-    if CONF_VANES_LR in config:
-        cg.add(var.set_vanesLR(config[CONF_VANES_LR]))
-    if CONF_SCK_PIN in config:
-        cg.add(var.set_sck_pin(config[CONF_SCK_PIN]))
-    if CONF_MOSI_PIN in config:
-        cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
-    if CONF_MISO_PIN in config:
-        cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
-
+# 1. Stelle (ca. Zeile 67)
 @automation.register_action(
     "climate.mhi.set_vertical_vanes",
     SetVerticalVanesAction,
@@ -64,15 +8,10 @@ async def to_code(config):
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=5)),
         }
     ),
-    [span_4](start_span)synchronous=False, # Korrektur für ESPHome 2026.3[span_4](end_span)
+    synchronous=False, # HIER stand vorher das [span_4] - bitte löschen!
 )
-async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
-    mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
-    var = cg.new_Pvariable(action_id, template_arg, mhi)
-    template_ = await cg.templatable(config[CONF_VANES_POSITION], args, int)
-    cg.add(var.set_position(template_))
-    return var
 
+# 2. Stelle
 @automation.register_action(
     "climate.mhi.set_horizontal_vanes",
     SetHorizontalVanesAction,
@@ -82,15 +21,10 @@ async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=8)),
         }
     ),
-    [span_5](start_span)synchronous=False, # Korrektur für ESPHome 2026.3[span_5](end_span)
+    synchronous=False, 
 )
-async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
-    mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
-    var = cg.new_Pvariable(action_id, template_arg, mhi)
-    template_ = await cg.templatable(config[CONF_VANES_POSITION], args, int)
-    cg.add(var.set_position(template_))
-    return var
 
+# 3. Stelle
 @automation.register_action(
     "climate.mhi.set_external_room_temperature",
     SetExternalRoomTemperatureAction,
@@ -100,11 +34,5 @@ async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_TEMPERATURE): cv.templatable(cv.float_),
         }
     ),
-    [span_6](start_span)synchronous=False, # Korrektur für ESPHome 2026.3[span_6](end_span)
+    synchronous=False,
 )
-async def set_external_room_temperature_to_code(config, action_id, template_arg, args):
-    mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
-    var = cg.new_Pvariable(action_id, template_arg, mhi)
-    template_ = await cg.templatable(config[CONF_TEMPERATURE], args, float)
-    cg.add(var.set_temperature(template_))
-    return var

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -1,4 +1,60 @@
-# 1. Stelle (ca. Zeile 67)
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.components import sensor
+from esphome.const import CONF_ID
+
+CONF_MHI_AC_CTRL_ID = "mhi_ac_ctrl_id"
+CONF_FRAME_SIZE = 'frame_size'
+CONF_ROOM_TEMP_TIMEOUT = 'room_temp_timeout'
+CONF_VANES_UD = 'initial_vertical_vanes_position'
+CONF_VANES_LR = 'initial_horizontal_vanes_position'
+CONF_SCK_PIN = "sck_pin"
+CONF_MOSI_PIN = "mosi_pin"
+CONF_MISO_PIN = "miso_pin"
+
+CONF_VANES_POSITION = 'position'
+CONF_TEMPERATURE = 'temperature'
+CONF_EXTERNAL_TEMPERATURE_SENSOR = 'external_temperature_sensor'
+
+mhi_ns = cg.esphome_ns.namespace('mhi')
+MhiAcCtrl = mhi_ns.class_('MhiPlatform', cg.Component)
+
+SetVerticalVanesAction = mhi_ns.class_("SetVerticalVanesAction", automation.Action)
+SetHorizontalVanesAction = mhi_ns.class_("SetHorizontalVanesAction", automation.Action)
+SetExternalRoomTemperatureAction = mhi_ns.class_("SetExternalRoomTemperatureAction", automation.Action)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(MhiAcCtrl),
+    cv.Optional(CONF_EXTERNAL_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
+    cv.Optional(CONF_FRAME_SIZE, default=20): cv.int_range(min=20, max=33),
+    cv.Optional(CONF_ROOM_TEMP_TIMEOUT, default=60): cv.int_range(min=0, max=3600),
+    cv.Optional(CONF_VANES_UD): cv.int_range(min=0, max=5),
+    cv.Optional(CONF_VANES_LR): cv.int_range(min=0, max=8),
+    cv.Optional(CONF_SCK_PIN): cv.int_,
+    cv.Optional(CONF_MOSI_PIN): cv.int_,
+    cv.Optional(CONF_MISO_PIN): cv.int_,
+}).extend(cv.COMPONENT_SCHEMA)
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    cg.add(var.set_frame_size(config[CONF_FRAME_SIZE]))
+    cg.add(var.set_room_temp_api_timeout(config[CONF_ROOM_TEMP_TIMEOUT]))
+    if CONF_EXTERNAL_TEMPERATURE_SENSOR in config:
+        sens = await cg.get_variable(config[CONF_EXTERNAL_TEMPERATURE_SENSOR])
+        cg.add(var.set_external_room_temperature_sensor(sens))
+    if CONF_VANES_UD in config:
+        cg.add(var.set_vanes(config[CONF_VANES_UD]))
+    if CONF_VANES_LR in config:
+        cg.add(var.set_vanesLR(config[CONF_VANES_LR]))
+    if CONF_SCK_PIN in config:
+        cg.add(var.set_sck_pin(config[CONF_SCK_PIN]))
+    if CONF_MOSI_PIN in config:
+        cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
+    if CONF_MISO_PIN in config:
+        cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
+
 @automation.register_action(
     "climate.mhi.set_vertical_vanes",
     SetVerticalVanesAction,
@@ -8,10 +64,15 @@
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=5)),
         }
     ),
-    synchronous=False, # HIER stand vorher das [span_4] - bitte löschen!
+    synchronous=False,
 )
+async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
+    mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
+    var = cg.new_Pvariable(action_id, template_arg, mhi)
+    template_ = await cg.templatable(config[CONF_VANES_POSITION], args, int)
+    cg.add(var.set_position(template_))
+    return var
 
-# 2. Stelle
 @automation.register_action(
     "climate.mhi.set_horizontal_vanes",
     SetHorizontalVanesAction,
@@ -21,10 +82,15 @@
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=8)),
         }
     ),
-    synchronous=False, 
+    synchronous=False,
 )
+async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
+    mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
+    var = cg.new_Pvariable(action_id, template_arg, mhi)
+    template_ = await cg.templatable(config[CONF_VANES_POSITION], args, int)
+    cg.add(var.set_position(template_))
+    return var
 
-# 3. Stelle
 @automation.register_action(
     "climate.mhi.set_external_room_temperature",
     SetExternalRoomTemperatureAction,
@@ -36,3 +102,9 @@
     ),
     synchronous=False,
 )
+async def set_external_room_temperature_to_code(config, action_id, template_arg, args):
+    mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
+    var = cg.new_Pvariable(action_id, template_arg, mhi)
+    template_ = await cg.templatable(config[CONF_TEMPERATURE], args, float)
+    cg.add(var.set_temperature(template_))
+    return va

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -64,7 +64,7 @@ async def to_code(config):
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=5)),
         }
     ),
-    synchronous=False, # Korrektur für ESPHome 2026.3
+    [span_4](start_span)synchronous=False, # Korrektur für ESPHome 2026.3[span_4](end_span)
 )
 async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
@@ -82,7 +82,7 @@ async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=8)),
         }
     ),
-    synchronous=False, # Korrektur für ESPHome 2026.3
+    [span_5](start_span)synchronous=False, # Korrektur für ESPHome 2026.3[span_5](end_span)
 )
 async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
@@ -100,7 +100,7 @@ async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_TEMPERATURE): cv.templatable(cv.float_),
         }
     ),
-    synchronous=False, # Korrektur für ESPHome 2026.3
+    [span_6](start_span)synchronous=False, # Korrektur für ESPHome 2026.3[span_6](end_span)
 )
 async def set_external_room_temperature_to_code(config, action_id, template_arg, args):
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -64,7 +64,7 @@ async def to_code(config):
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=5)),
         }
     ),
-    synchronous=True,
+    synchronous=False, # Korrektur für ESPHome 2026.3
 )
 async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
@@ -82,7 +82,7 @@ async def set_vertical_vanes_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_VANES_POSITION): cv.templatable(cv.int_range(min=1, max=8)),
         }
     ),
-    synchronous=True,
+    synchronous=False, # Korrektur für ESPHome 2026.3
 )
 async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])
@@ -90,7 +90,6 @@ async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
     template_ = await cg.templatable(config[CONF_VANES_POSITION], args, int)
     cg.add(var.set_position(template_))
     return var
-
 
 @automation.register_action(
     "climate.mhi.set_external_room_temperature",
@@ -101,7 +100,7 @@ async def set_horizontal_vanes_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_TEMPERATURE): cv.templatable(cv.float_),
         }
     ),
-    synchronous=True,
+    synchronous=False, # Korrektur für ESPHome 2026.3
 )
 async def set_external_room_temperature_to_code(config, action_id, template_arg, args):
     mhi = await cg.get_variable(config[CONF_MHI_AC_CTRL_ID])

--- a/components/MhiAcCtrl/__init__.py
+++ b/components/MhiAcCtrl/__init__.py
@@ -107,4 +107,4 @@ async def set_external_room_temperature_to_code(config, action_id, template_arg,
     var = cg.new_Pvariable(action_id, template_arg, mhi)
     template_ = await cg.templatable(config[CONF_TEMPERATURE], args, float)
     cg.add(var.set_temperature(template_))
-    return va
+    return var

--- a/components/MhiAcCtrl/climate/__init__.py
+++ b/components/MhiAcCtrl/climate/__init__.py
@@ -20,8 +20,11 @@ CONFIG_SCHEMA = climate.climate_schema(MhiClimate).extend(
         cv.GenerateID(CONF_MHI_AC_CTRL_ID): cv.use_id(MhiAcCtrl),
         cv.Optional(CONF_TEMPERATURE_OFFSET, default=False): cv.boolean,
         cv.Optional(CONF_VISUAL_MIN_TEMPERATURE, default=18.0): cv.temperature,
+        # Diese Zeile erzwingt, dass kein Icon-Code generiert wird, der set_icon aufruft:
+        cv.Optional("icon"): cv.invalid("Icons werden für diese Komponente in 2026.3 via C++ nicht unterstützt"),
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
 
 
 

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -15,17 +15,10 @@ void MhiClimate::setup() {
         restore->apply(this);
     } else {
         this->mode = climate::CLIMATE_MODE_OFF;
-        this->target_temperature = roundf(clamp(
-            this->current_temperature, this->minimum_temperature_, this->maximum_temperature_));
+        this->target_temperature = 20;
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
         this->swing_mode = climate::CLIMATE_SWING_OFF;
     }
-    if (isnan(this->target_temperature))
-        this->target_temperature = 20;
-
-    this->vanesLR_pos_old_state_ = 4;
-    this->vanes_pos_old_state_ = 4;
-
     this->platform_ = this->parent_;
     this->platform_->add_listener(this);
 }
@@ -35,155 +28,19 @@ void MhiClimate::dump_config() {
 }
 
 void MhiClimate::update_status(ACStatus status, int value) {
-    static int mode_tmp = 0xff;
     if (this->power_ == power_off) {
         this->mode = climate::CLIMATE_MODE_OFF;
-        this->publish_state();
     }
-
-    switch (status) {
-    case status_power:
-        if (value == power_on) {
-            this->power_ = power_on;
-            update_status(status_mode, mode_tmp);
-        } else {
-            this->power_ = power_off;
-            this->mode = climate::CLIMATE_MODE_OFF;
-            this->publish_state();
-        }
-        break;
-    case status_mode:
-        mode_tmp = value;
-    case opdata_mode:
-    case erropdata_mode:
-        switch (value) {
-        case mode_auto:          
-            if (status != erropdata_mode && this->power_ > 0) {
-                this->mode = climate::CLIMATE_MODE_HEAT_COOL;
-            } else {
-                this->mode = climate::CLIMATE_MODE_OFF;
-            }
-            break;
-        case mode_dry:
-            this->mode = climate::CLIMATE_MODE_DRY;
-            break;
-        case mode_cool:
-            this->mode = climate::CLIMATE_MODE_COOL;
-            break;
-        case mode_fan:
-            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-        case mode_heat:
-            this->mode = climate::CLIMATE_MODE_HEAT;
-            break;
-        }
-        this->publish_state();
-        break;
-    case status_fan:
-        switch (value) {
-        case 0: this->fan_mode = climate::CLIMATE_FAN_QUIET; break;
-        case 1: this->fan_mode = climate::CLIMATE_FAN_LOW; break;
-        case 2: this->fan_mode = climate::CLIMATE_FAN_MEDIUM; break;
-        case 6: this->fan_mode = climate::CLIMATE_FAN_HIGH; break;
-        case 7: this->fan_mode = climate::CLIMATE_FAN_AUTO; break;
-        }
-        this->publish_state();
-        break;
-    case status_vanes:
-        if (this->vanesLR_pos_state_ == vanesLR_swing) {
-            switch (value) {
-                case vanes_swing: this->swing_mode = climate::CLIMATE_SWING_BOTH; break;
-                default: this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL; this->vanes_pos_old_state_ = value; break;
-            }
-        } else {
-            switch (value) {
-                case vanes_swing: this->swing_mode = climate::CLIMATE_SWING_VERTICAL; break;
-                default: this->swing_mode = climate::CLIMATE_SWING_OFF; this->vanes_pos_old_state_ = value; break;
-            }
-        }
-        this->vanes_pos_state_ = value;
-        this->publish_state();
-        break;
-    case status_vanesLR:
-        if (this->vanes_pos_state_ == vanes_swing) {
-            switch (value) {
-                case vanesLR_swing: this->swing_mode = climate::CLIMATE_SWING_BOTH; break;
-                default: this->swing_mode = climate::CLIMATE_SWING_VERTICAL; this->vanesLR_pos_old_state_ = value; break;
-            }
-        } else {
-            switch (value) {
-                case vanesLR_swing: this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL; break;
-                default: this->swing_mode = climate::CLIMATE_SWING_OFF; this->vanesLR_pos_old_state_ = value; break;
-            }
-        }
-        this->vanesLR_pos_state_ = value;
-        this->publish_state();
-        break;
-    case status_troom:
-        this->current_temperature = ((value - 61) / 4.0) - this->temperature_offset_;
-        this->publish_state();
-        break;
-    case status_tsetpoint: {
-        float ac_setpoint = (value & 0x7f) / 2.0;
-        if (this->temperature_offset_ != 0.0 && fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1) break;
-        this->target_temperature = ac_setpoint;
-        this->temperature_offset_ = 0.0;
-        this->publish_state();
-        break;
-    }
-    }
+    // Hier folgt die restliche Logik der Komponente...
+    this->publish_state();
 }
 
 void MhiClimate::control(const climate::ClimateCall& call) {
     if (call.get_target_temperature().has_value()) {
-        float target_temp = *call.get_target_temperature();
-        this->target_temperature = target_temp;
-        const float ac_unit_min_temp = 18.0f;
-        float setpoint = ceil(target_temp);
-        if (setpoint < ac_unit_min_temp) setpoint = ac_unit_min_temp;
-        float offset = 0.0;
-        if (this->temperature_offset_enabled_) offset = setpoint - target_temp;
-        this->platform_->set_offset(offset);
-        this->temperature_offset_ = offset;
-        this->platform_->set_tsetpoint(setpoint);
+        this->target_temperature = *call.get_target_temperature();
     }
     if (call.get_mode().has_value()) {
         this->mode = *call.get_mode();
-        this->power_ = power_on;
-        switch (this->mode) {
-        case climate::CLIMATE_MODE_OFF: power_ = power_off; break;
-        case climate::CLIMATE_MODE_COOL: mode_ = mode_cool; break;
-        case climate::CLIMATE_MODE_HEAT: mode_ = mode_heat; break;
-        case climate::CLIMATE_MODE_DRY: mode_ = mode_dry; break;
-        case climate::CLIMATE_MODE_FAN_ONLY: mode_ = mode_fan; break;
-        default: mode_ = mode_auto; break;
-        }
-        this->platform_->set_power(power_);
-        this->platform_->set_mode(mode_);
-    }
-    if (call.get_fan_mode().has_value()) {
-        this->fan_mode = *call.get_fan_mode();
-        switch (*this->fan_mode) {
-        case climate::CLIMATE_FAN_QUIET: fan_ = 0; break;
-        case climate::CLIMATE_FAN_LOW: fan_ = 1; break;
-        case climate::CLIMATE_FAN_MEDIUM: fan_ = 2; break;
-        case climate::CLIMATE_FAN_HIGH: fan_ = 6; break;
-        default: fan_ = 7; break;
-        }
-        this->platform_->set_fan(fan_);
-    }
-    if (call.get_swing_mode().has_value()) {
-        this->swing_mode = *call.get_swing_mode();
-        vanesLR_ = static_cast<ACVanesLR>(this->vanesLR_pos_old_state_);
-        vanes_ = static_cast<ACVanes>(this->vanes_pos_old_state_);
-        switch (this->swing_mode) {
-        case climate::CLIMATE_SWING_VERTICAL: vanes_ = vanes_swing; break;
-        case climate::CLIMATE_SWING_HORIZONTAL: vanesLR_ = vanesLR_swing; break;
-        case climate::CLIMATE_SWING_BOTH: vanesLR_ = vanesLR_swing; vanes_ = vanes_swing; break;
-        default: break;
-        }
-        this->platform_->set_vanesLR(vanesLR_);
-        this->platform_->set_vanes(vanes_);
     }
     this->publish_state();
 }
@@ -191,13 +48,30 @@ void MhiClimate::control(const climate::ClimateCall& call) {
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
+    traits.set_supported_modes({
+        climate::CLIMATE_MODE_OFF, 
+        climate::CLIMATE_MODE_HEAT_COOL, 
+        climate::CLIMATE_MODE_COOL, 
+        climate::CLIMATE_MODE_HEAT, 
+        climate::CLIMATE_MODE_DRY, 
+        climate::CLIMATE_MODE_FAN_ONLY
+    });
     traits.set_visual_min_temperature(this->minimum_temperature_);
     traits.set_visual_max_temperature(this->maximum_temperature_);
     traits.set_visual_temperature_step(this->temperature_step_);
-    [span_11](start_span)// KORREKTUR: Überall climate:: hinzugefügt[span_11](end_span)
-    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
-    traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
+    traits.set_supported_fan_modes({
+        climate::CLIMATE_FAN_AUTO, 
+        climate::CLIMATE_FAN_QUIET, 
+        climate::CLIMATE_FAN_LOW, 
+        climate::CLIMATE_FAN_MEDIUM, 
+        climate::CLIMATE_FAN_HIGH
+    });
+    traits.set_supported_swing_modes({
+        climate::CLIMATE_SWING_OFF, 
+        climate::CLIMATE_SWING_BOTH, 
+        climate::CLIMATE_SWING_VERTICAL, 
+        climate::CLIMATE_SWING_HORIZONTAL
+    });
     return traits;
 }
 

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -77,7 +77,7 @@ void MhiClimate::update_status(ACStatus status, int value) {
             break;
         case mode_heat:
             this->mode = climate::CLIMATE_MODE_HEAT;
-            this->platform_->set_vanes(vanes_4); // SMART LOGIC: Konvektion (Unten)
+            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
             break;
         default:
             ESP_LOGD(TAG, "unknown status mode value %i", value);
@@ -194,7 +194,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
             break;
         case climate::CLIMATE_MODE_HEAT:
             mode_ = mode_heat;
-            this->platform_->set_vanes(vanes_4); // SMART LOGIC: Konvektion (Unten)
+            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
             break;
         case climate::CLIMATE_MODE_DRY:
             mode_ = mode_dry;

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -77,7 +77,7 @@ void MhiClimate::update_status(ACStatus status, int value) {
             break;
         case mode_heat:
             this->mode = climate::CLIMATE_MODE_HEAT;
-            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
+            this->platform_->set_vanes(vanes_4); // SMART LOGIC: Konvektion (Unten)
             break;
         default:
             ESP_LOGD(TAG, "unknown status mode value %i", value);
@@ -194,7 +194,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
             break;
         case climate::CLIMATE_MODE_HEAT:
             mode_ = mode_heat;
-            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
+            this->platform_->set_vanes(vanes_4); // SMART LOGIC: Konvektion (Unten)
             break;
         case climate::CLIMATE_MODE_DRY:
             mode_ = mode_dry;

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -340,11 +340,12 @@ void MhiClimate::control(const climate::ClimateCall& call) {
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY,climate::CLIMATE_MODE_FAN_ONLY });
+    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
     traits.set_visual_min_temperature(this->minimum_temperature_);
     traits.set_visual_max_temperature(this->maximum_temperature_);
     traits.set_visual_temperature_step(this->temperature_step_);
-    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
+    // KORREKTUR: Überall climate:: hinzugefügt
+    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
     traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
     return traits;
 }
@@ -352,16 +353,18 @@ climate::ClimateTraits MhiClimate::traits() {
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.set_supports_current_temperature(true);
-    traits.set_supported_modes({ CLIMATE_MODE_OFF, CLIMATE_MODE_HEAT_COOL, CLIMATE_MODE_COOL, CLIMATE_MODE_HEAT, CLIMATE_MODE_DRY, CLIMATE_MODE_FAN_ONLY });
+    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
     traits.set_supports_two_point_target_temperature(false);
     traits.set_visual_min_temperature(this->minimum_temperature_);
     traits.set_visual_max_temperature(this->maximum_temperature_);
     traits.set_visual_temperature_step(this->temperature_step_);
-    traits.set_supported_fan_modes({ CLIMATE_FAN_AUTO, CLIMATE_FAN_QUIET, CLIMATE_FAN_LOW, CLIMATE_FAN_MEDIUM, CLIMATE_FAN_HIGH });
-    traits.set_supported_swing_modes({ CLIMATE_SWING_OFF, CLIMATE_SWING_BOTH, CLIMATE_SWING_VERTICAL, CLIMATE_SWING_HORIZONTAL });
+    // KORREKTUR: Überall climate:: hinzugefügt
+    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
+    traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
     return traits;
 }
 #endif
+
 
 
 } //namespace mhi

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -15,10 +15,17 @@ void MhiClimate::setup() {
         restore->apply(this);
     } else {
         this->mode = climate::CLIMATE_MODE_OFF;
-        this->target_temperature = 20;
+        this->target_temperature = roundf(clamp(
+            this->current_temperature, this->minimum_temperature_, this->maximum_temperature_));
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
         this->swing_mode = climate::CLIMATE_SWING_OFF;
     }
+    if (isnan(this->target_temperature))
+        this->target_temperature = 20;
+
+    this->vanesLR_pos_old_state_ = 4;
+    this->vanes_pos_old_state_ = 4;
+
     this->platform_ = this->parent_;
     this->platform_->add_listener(this);
 }
@@ -28,52 +35,249 @@ void MhiClimate::dump_config() {
 }
 
 void MhiClimate::update_status(ACStatus status, int value) {
+    static int mode_tmp = 0xff;
+
     if (this->power_ == power_off) {
         this->mode = climate::CLIMATE_MODE_OFF;
+        this->publish_state();
     }
-    // Hier folgt die restliche Logik der Komponente...
-    this->publish_state();
+
+    switch (status) {
+    case status_power:
+        if (value == power_on) {
+            this->power_ = power_on;
+            update_status(status_mode, mode_tmp);
+        } else {
+            this->power_ = power_off;
+            this->mode = climate::CLIMATE_MODE_OFF;
+            this->publish_state();
+        }
+        break;
+    case status_mode:
+        mode_tmp = value;
+    case opdata_mode:
+    case erropdata_mode:
+        switch (value) {
+        case mode_auto:          
+            if (status != erropdata_mode && this->power_ > 0) {
+                this->mode = climate::CLIMATE_MODE_HEAT_COOL;
+            } else {
+                this->mode = climate::CLIMATE_MODE_OFF;
+            }
+            break;
+        case mode_dry:
+            this->mode = climate::CLIMATE_MODE_DRY;
+            break;
+        case mode_cool:
+            this->mode = climate::CLIMATE_MODE_COOL;
+            this->platform_->set_vanes(vanes_1); // SMART LOGIC: Coanda (Oben)
+            break;
+        case mode_fan:
+            this->mode = climate::CLIMATE_MODE_FAN_ONLY;
+            break;
+        case mode_heat:
+            this->mode = climate::CLIMATE_MODE_HEAT;
+            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
+            break;
+        default:
+            ESP_LOGD(TAG, "unknown status mode value %i", value);
+        }
+        this->publish_state();
+        break;
+    case status_fan:
+        switch (value) {
+        case 0: this->fan_mode = climate::CLIMATE_FAN_QUIET; break;
+        case 1: this->fan_mode = climate::CLIMATE_FAN_LOW; break;
+        case 2: this->fan_mode = climate::CLIMATE_FAN_MEDIUM; break;
+        case 6: this->fan_mode = climate::CLIMATE_FAN_HIGH; break;
+        case 7: this->fan_mode = climate::CLIMATE_FAN_AUTO; break;
+        }
+        this->publish_state();
+        break;
+    case status_vanes:
+        if (this->vanesLR_pos_state_ == vanesLR_swing) {
+            switch (value) {
+                case vanes_unknown: case vanes_1: case vanes_2: case vanes_3: case vanes_4:
+                    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+                    this->vanes_pos_old_state_ = value;
+                    break;
+                case vanes_swing:
+                    this->swing_mode = climate::CLIMATE_SWING_BOTH;
+                    break;
+            }
+        } else {
+            switch (value) {
+                case vanes_unknown: case vanes_1: case vanes_2: case vanes_3: case vanes_4:
+                    this->swing_mode = climate::CLIMATE_SWING_OFF;
+                    this->vanes_pos_old_state_ = value;
+                    break;
+                case vanes_swing:
+                    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+                    break;
+            }
+        }
+        this->vanes_pos_state_ = value;
+        this->publish_state();
+        break;
+    case status_vanesLR:
+        if (this->vanes_pos_state_ == vanes_swing) {
+            switch (value) {
+                case vanesLR_1: case vanesLR_2: case vanesLR_3: case vanesLR_4: case vanesLR_5: case vanesLR_6: case vanesLR_7:
+                    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
+                    this->vanesLR_pos_old_state_ = value;
+                    break;
+                case vanesLR_swing:
+                    this->swing_mode = climate::CLIMATE_SWING_BOTH;
+                    break;
+            }
+        } else {
+            switch (value) {
+                case vanesLR_1: case vanesLR_2: case vanesLR_3: case vanesLR_4: case vanesLR_5: case vanesLR_6: case vanesLR_7:
+                    this->swing_mode = climate::CLIMATE_SWING_OFF;
+                    this->vanesLR_pos_old_state_ = value;
+                    break;
+                case vanesLR_swing:
+                    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
+                    break;
+            }
+        }
+        this->publish_state();
+        this->vanesLR_pos_state_ = value;
+        break;
+    case status_troom:
+        this->current_temperature = ((value - 61) / 4.0) - this->temperature_offset_;
+        this->publish_state();
+        break;
+    case status_tsetpoint: {
+        float ac_setpoint = (value & 0x7f) / 2.0;
+        if (this->temperature_offset_ != 0.0 && 
+            fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1) {
+            break;
+        }
+        this->target_temperature = ac_setpoint;
+        this->temperature_offset_ = 0.0;
+        this->publish_state();
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 void MhiClimate::control(const climate::ClimateCall& call) {
     if (call.get_target_temperature().has_value()) {
-        this->target_temperature = *call.get_target_temperature();
+        float target_temp = *call.get_target_temperature();
+        this->target_temperature = target_temp; 
+        const float ac_unit_min_temp = 18.0f; 
+        float setpoint = ceil(target_temp);
+        if (setpoint < ac_unit_min_temp)
+            setpoint = ac_unit_min_temp;
+        float offset = 0.0;
+        if (this->temperature_offset_enabled_) {
+            offset = setpoint - target_temp;
+        }
+        this->platform_->set_offset(offset);
+        this->temperature_offset_ = offset;
+        this->platform_->set_tsetpoint(setpoint);
     }
+
     if (call.get_mode().has_value()) {
         this->mode = *call.get_mode();
+        this->power_ = power_on;
+        switch (this->mode) {
+        case climate::CLIMATE_MODE_OFF:
+            power_ = power_off;
+            break;
+        case climate::CLIMATE_MODE_COOL:
+            mode_ = mode_cool;
+            this->platform_->set_vanes(vanes_1); // SMART LOGIC: Coanda (Oben)
+            break;
+        case climate::CLIMATE_MODE_HEAT:
+            mode_ = mode_heat;
+            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
+            break;
+        case climate::CLIMATE_MODE_DRY:
+            mode_ = mode_dry;
+            break;
+        case climate::CLIMATE_MODE_FAN_ONLY:
+            mode_ = mode_fan;
+            break;
+        case climate::CLIMATE_MODE_HEAT_COOL:
+        default:
+            mode_ = mode_auto;
+            break;
+        }
+        this->platform_->set_power(power_);
+        this->platform_->set_mode(mode_);
     }
+
+    if (call.get_fan_mode().has_value()) {
+        this->fan_mode = *call.get_fan_mode();
+        switch (*this->fan_mode) {
+        case climate::CLIMATE_FAN_QUIET: fan_ = 0; break;
+        case climate::CLIMATE_FAN_LOW: fan_ = 1; break;
+        case climate::CLIMATE_FAN_MEDIUM: fan_ = 2; break;
+        case climate::CLIMATE_FAN_HIGH: fan_ = 6; break;
+        case climate::CLIMATE_FAN_AUTO:
+        default: fan_ = 7; break;
+        }
+        this->platform_->set_fan(fan_);
+    }
+
+    if (call.get_swing_mode().has_value()) {
+        this->swing_mode = *call.get_swing_mode();
+        vanesLR_ = static_cast<ACVanesLR>(this->vanesLR_pos_old_state_);
+        vanes_ = static_cast<ACVanes>(this->vanes_pos_old_state_);
+
+        switch (this->swing_mode) {
+        case climate::CLIMATE_SWING_OFF:
+            break;
+        case climate::CLIMATE_SWING_VERTICAL:
+            vanes_ = vanes_swing;
+            break;
+        case climate::CLIMATE_SWING_HORIZONTAL:
+            vanesLR_ = vanesLR_swing;
+            break;
+        default:
+        case climate::CLIMATE_SWING_BOTH:
+            vanesLR_ = vanesLR_swing;
+            vanes_ = vanes_swing;
+            break;
+        }
+        this->platform_->set_vanesLR(vanesLR_); 
+        this->platform_->set_vanes(vanes_); 
+    }
+
     this->publish_state();
 }
 
+/// Return the traits of this controller.
+#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    traits.set_supported_modes({
-        climate::CLIMATE_MODE_OFF, 
-        climate::CLIMATE_MODE_HEAT_COOL, 
-        climate::CLIMATE_MODE_COOL, 
-        climate::CLIMATE_MODE_HEAT, 
-        climate::CLIMATE_MODE_DRY, 
-        climate::CLIMATE_MODE_FAN_ONLY
-    });
+    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
     traits.set_visual_min_temperature(this->minimum_temperature_);
     traits.set_visual_max_temperature(this->maximum_temperature_);
     traits.set_visual_temperature_step(this->temperature_step_);
-    traits.set_supported_fan_modes({
-        climate::CLIMATE_FAN_AUTO, 
-        climate::CLIMATE_FAN_QUIET, 
-        climate::CLIMATE_FAN_LOW, 
-        climate::CLIMATE_FAN_MEDIUM, 
-        climate::CLIMATE_FAN_HIGH
-    });
-    traits.set_supported_swing_modes({
-        climate::CLIMATE_SWING_OFF, 
-        climate::CLIMATE_SWING_BOTH, 
-        climate::CLIMATE_SWING_VERTICAL, 
-        climate::CLIMATE_SWING_HORIZONTAL
-    });
+    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
+    traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
     return traits;
 }
+#else
+climate::ClimateTraits MhiClimate::traits() {
+    auto traits = climate::ClimateTraits();
+    traits.set_supports_current_temperature(true);
+    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
+    traits.set_supports_two_point_target_temperature(false);
+    traits.set_visual_min_temperature(this->minimum_temperature_);
+    traits.set_visual_max_temperature(this->maximum_temperature_);
+    traits.set_visual_temperature_step(this->temperature_step_);
+    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
+    traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
+    return traits;
+}
+#endif
 
 } //namespace mhi
 } //namespace esphome

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -201,8 +201,7 @@ void MhiClimate::control(const climate::ClimateCall& call) {
             
         case climate::CLIMATE_MODE_HEAT:
             mode_ = mode_heat;
-            this->platform_->set_vanes(vanes_5);  // SMART LOGIC: Konvektion (Ganz Unten)
-            
+            this->platform_->set_vanes(vanes_5);  // SMART LOGIC: Konvektion (Ganz Unten)            
             // FIX: Verhindert, dass Home Assistant beim Moduswechsel ungewollt alte Zustände mitsendet
             if (this->swing_mode != climate::CLIMATE_SWING_OFF) {
                 this->swing_mode = climate::CLIMATE_SWING_OFF;

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -10,20 +10,16 @@ static const char* TAG = "mhi.climate";
 void MhiClimate::setup() {
     this->power_ = power_off;
     this->current_temperature = NAN;
-    // restore set points
     auto restore = this->restore_state_();
     if (restore.has_value()) {
         restore->apply(this);
     } else {
-        // restore from defaults
         this->mode = climate::CLIMATE_MODE_OFF;
-        // initialize target temperature to some value so that it's not NAN
         this->target_temperature = roundf(clamp(
             this->current_temperature, this->minimum_temperature_, this->maximum_temperature_));
         this->fan_mode = climate::CLIMATE_FAN_AUTO;
         this->swing_mode = climate::CLIMATE_SWING_OFF;
     }
-    // Never send nan to HA
     if (isnan(this->target_temperature))
         this->target_temperature = 20;
 
@@ -32,7 +28,6 @@ void MhiClimate::setup() {
 
     this->platform_ = this->parent_;
     this->platform_->add_listener(this);
-    
 }
 
 void MhiClimate::dump_config() {
@@ -40,14 +35,8 @@ void MhiClimate::dump_config() {
 }
 
 void MhiClimate::update_status(ACStatus status, int value) {
-
     static int mode_tmp = 0xff;
-
-    
-    ESP_LOGD(TAG, "received status=%i value=%i power=%i", status, value, this->power_);
-
     if (this->power_ == power_off) {
-        // Workaround for status after reboot
         this->mode = climate::CLIMATE_MODE_OFF;
         this->publish_state();
     }
@@ -56,11 +45,8 @@ void MhiClimate::update_status(ACStatus status, int value) {
     case status_power:
         if (value == power_on) {
             this->power_ = power_on;
-            // output_P(status, (TOPIC_POWER), PSTR(PAYLOAD_POWER_ON));
             update_status(status_mode, mode_tmp);
         } else {
-            // output_P(status, (TOPIC_POWER), (PAYLOAD_POWER_OFF));
-            // output_P(status, PSTR(TOPIC_MODE), PSTR(PAYLOAD_MODE_OFF));
             this->power_ = power_off;
             this->mode = climate::CLIMATE_MODE_OFF;
             this->publish_state();
@@ -79,78 +65,41 @@ void MhiClimate::update_status(ACStatus status, int value) {
             }
             break;
         case mode_dry:
-            // output_P(status, PSTR(TOPIC_MODE), PSTR(PAYLOAD_MODE_DRY));
             this->mode = climate::CLIMATE_MODE_DRY;
             break;
         case mode_cool:
-            // output_P(status, PSTR(TOPIC_MODE), PSTR(PAYLOAD_MODE_COOL));
             this->mode = climate::CLIMATE_MODE_COOL;
             break;
         case mode_fan:
-            // output_P(status, PSTR(TOPIC_MODE), PSTR(PAYLOAD_MODE_FAN));
             this->mode = climate::CLIMATE_MODE_FAN_ONLY;
             break;
         case mode_heat:
-            // output_P(status, PSTR(TOPIC_MODE), PSTR(PAYLOAD_MODE_HEAT));
             this->mode = climate::CLIMATE_MODE_HEAT;
             break;
-        default:
-            ESP_LOGD(TAG, "unknown status mode value %i", value);
         }
         this->publish_state();
         break;
     case status_fan:
         switch (value) {
-        case 0:
-            this->fan_mode = climate::CLIMATE_FAN_QUIET;
-            break;
-        case 1:
-            this->fan_mode = climate::CLIMATE_FAN_LOW;
-            break;
-        case 2:
-            this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
-            break;
-        case 6:
-            this->fan_mode = climate::CLIMATE_FAN_HIGH;
-            break;
-        case 7:
-            this->fan_mode = climate::CLIMATE_FAN_AUTO;
-            break;
+        case 0: this->fan_mode = climate::CLIMATE_FAN_QUIET; break;
+        case 1: this->fan_mode = climate::CLIMATE_FAN_LOW; break;
+        case 2: this->fan_mode = climate::CLIMATE_FAN_MEDIUM; break;
+        case 6: this->fan_mode = climate::CLIMATE_FAN_HIGH; break;
+        case 7: this->fan_mode = climate::CLIMATE_FAN_AUTO; break;
         }
         this->publish_state();
         break;
     case status_vanes:
-        // Vanes Up Down, also known as Vertical
         if (this->vanesLR_pos_state_ == vanesLR_swing) {
             switch (value) {
-                case vanes_unknown:
-                case vanes_1:
-                case vanes_2:
-                case vanes_3:
-                case vanes_4:
-                    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-                    this->vanes_pos_old_state_ = value;
-                    break;
-                case vanes_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_BOTH;
-                    break;
+                case vanes_swing: this->swing_mode = climate::CLIMATE_SWING_BOTH; break;
+                default: this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL; this->vanes_pos_old_state_ = value; break;
             }
-        }
-        else {
+        } else {
             switch (value) {
-                case vanes_unknown:
-                case vanes_1:
-                case vanes_2:
-                case vanes_3:
-                case vanes_4:
-                    this->swing_mode = climate::CLIMATE_SWING_OFF;
-                    this->vanes_pos_old_state_ = value;
-                    break;
-                case vanes_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-                    break;
+                case vanes_swing: this->swing_mode = climate::CLIMATE_SWING_VERTICAL; break;
+                default: this->swing_mode = climate::CLIMATE_SWING_OFF; this->vanes_pos_old_state_ = value; break;
             }
-
         }
         this->vanes_pos_state_ = value;
         this->publish_state();
@@ -158,185 +107,87 @@ void MhiClimate::update_status(ACStatus status, int value) {
     case status_vanesLR:
         if (this->vanes_pos_state_ == vanes_swing) {
             switch (value) {
-                case vanesLR_1:
-                case vanesLR_2:
-                case vanesLR_3:
-                case vanesLR_4:
-                case vanesLR_5:
-                case vanesLR_6:
-                case vanesLR_7:
-                    this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
-                    this->vanesLR_pos_old_state_ = value;
-                    break;
-                case vanesLR_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_BOTH;
-                    break;
+                case vanesLR_swing: this->swing_mode = climate::CLIMATE_SWING_BOTH; break;
+                default: this->swing_mode = climate::CLIMATE_SWING_VERTICAL; this->vanesLR_pos_old_state_ = value; break;
             }
-        }
-        else {
+        } else {
             switch (value) {
-                case vanesLR_1:
-                case vanesLR_2:
-                case vanesLR_3:
-                case vanesLR_4:
-                case vanesLR_5:
-                case vanesLR_6:
-                case vanesLR_7:
-                    this->swing_mode = climate::CLIMATE_SWING_OFF;
-                    this->vanesLR_pos_old_state_ = value;
-                    break;
-                case vanesLR_swing:
-                    this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL;
-                    break;
+                case vanesLR_swing: this->swing_mode = climate::CLIMATE_SWING_HORIZONTAL; break;
+                default: this->swing_mode = climate::CLIMATE_SWING_OFF; this->vanesLR_pos_old_state_ = value; break;
             }
-
         }
-        this->publish_state();
         this->vanesLR_pos_state_ = value;
+        this->publish_state();
         break;
     case status_troom:
-        // Calculate the temperature and apply the offset for 0.5°C steps
         this->current_temperature = ((value - 61) / 4.0) - this->temperature_offset_;
         this->publish_state();
         break;
-
     case status_tsetpoint: {
         float ac_setpoint = (value & 0x7f) / 2.0;
-
-        // If we are using an offset, check if the AC's update is just an
-        // echo of the command we already sent (our target + our offset).
-        if (this->temperature_offset_ != 0.0 && 
-            fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1) {
-            
-            // This is an expected echo. Do nothing to prevent overwriting our state.
-            ESP_LOGD(TAG, "Ignoring tsetpoint echo from AC: %.1f", ac_setpoint);
-            break;
-        }
-
-        // If it's not an echo, it's a new value from the remote.
-        // Update the target temperature and reset the offset.
-        ESP_LOGI(TAG, "Remote setpoint change detected. Updating target to %.1f", ac_setpoint);
+        if (this->temperature_offset_ != 0.0 && fabs(ac_setpoint - (this->target_temperature + this->temperature_offset_)) < 0.1) break;
         this->target_temperature = ac_setpoint;
         this->temperature_offset_ = 0.0;
         this->publish_state();
         break;
     }
-    default:
-        // skip these values as they are not used currently
-        break;
     }
 }
 
 void MhiClimate::control(const climate::ClimateCall& call) {
     if (call.get_target_temperature().has_value()) {
         float target_temp = *call.get_target_temperature();
-        this->target_temperature = target_temp; // Store the user's desired temp
-
-        ESP_LOGD(TAG, "MhiClimate::control - get_target_temperature - New target_temperature: %.1f°C", target_temp);
-
-        const float ac_unit_min_temp = 18.0f; // Hardware minimum for the AC unit
-
+        this->target_temperature = target_temp;
+        const float ac_unit_min_temp = 18.0f;
         float setpoint = ceil(target_temp);
-        if (setpoint < ac_unit_min_temp)
-            setpoint = ac_unit_min_temp;
-
+        if (setpoint < ac_unit_min_temp) setpoint = ac_unit_min_temp;
         float offset = 0.0;
-        if (this->temperature_offset_enabled_) {
-            offset = setpoint - target_temp;
-        }
+        if (this->temperature_offset_enabled_) offset = setpoint - target_temp;
         this->platform_->set_offset(offset);
         this->temperature_offset_ = offset;
         this->platform_->set_tsetpoint(setpoint);
-
-        ESP_LOGD(TAG, "MhiClimate::control - get_target_temperature - set_tsetpoint %f, set_offset %f", setpoint, offset);
     }
-
     if (call.get_mode().has_value()) {
         this->mode = *call.get_mode();
-        
         this->power_ = power_on;
         switch (this->mode) {
-        case climate::CLIMATE_MODE_OFF:
-            power_ = power_off;
-            break;
-        case climate::CLIMATE_MODE_COOL:
-            mode_ = mode_cool;
-            break;
-        case climate::CLIMATE_MODE_HEAT:
-            mode_ = mode_heat;
-            break;
-        case climate::CLIMATE_MODE_DRY:
-            mode_ = mode_dry;
-            break;
-        case climate::CLIMATE_MODE_FAN_ONLY:
-            mode_ = mode_fan;
-            break;
-        case climate::CLIMATE_MODE_HEAT_COOL:
-        default:
-            mode_ = mode_auto;
-            break;
+        case climate::CLIMATE_MODE_OFF: power_ = power_off; break;
+        case climate::CLIMATE_MODE_COOL: mode_ = mode_cool; break;
+        case climate::CLIMATE_MODE_HEAT: mode_ = mode_heat; break;
+        case climate::CLIMATE_MODE_DRY: mode_ = mode_dry; break;
+        case climate::CLIMATE_MODE_FAN_ONLY: mode_ = mode_fan; break;
+        default: mode_ = mode_auto; break;
         }
-
         this->platform_->set_power(power_);
         this->platform_->set_mode(mode_);
     }
-
     if (call.get_fan_mode().has_value()) {
         this->fan_mode = *call.get_fan_mode();
-
         switch (*this->fan_mode) {
-        case climate::CLIMATE_FAN_QUIET:
-            fan_ = 0;
-            break;
-        case climate::CLIMATE_FAN_LOW:
-            fan_ = 1;
-            break;
-        case climate::CLIMATE_FAN_MEDIUM:
-            fan_ = 2;
-            break;
-        case climate::CLIMATE_FAN_HIGH:
-            fan_ = 6;
-            break;
-        case climate::CLIMATE_FAN_AUTO:
-        default:
-            fan_ = 7;
-            break;
+        case climate::CLIMATE_FAN_QUIET: fan_ = 0; break;
+        case climate::CLIMATE_FAN_LOW: fan_ = 1; break;
+        case climate::CLIMATE_FAN_MEDIUM: fan_ = 2; break;
+        case climate::CLIMATE_FAN_HIGH: fan_ = 6; break;
+        default: fan_ = 7; break;
         }
-
         this->platform_->set_fan(fan_);
     }
-
     if (call.get_swing_mode().has_value()) {
         this->swing_mode = *call.get_swing_mode();
         vanesLR_ = static_cast<ACVanesLR>(this->vanesLR_pos_old_state_);
         vanes_ = static_cast<ACVanes>(this->vanes_pos_old_state_);
-
         switch (this->swing_mode) {
-        case climate::CLIMATE_SWING_OFF:
-            break;
-        case climate::CLIMATE_SWING_VERTICAL:
-            vanes_ = vanes_swing;
-            break;
-        case climate::CLIMATE_SWING_HORIZONTAL:
-            vanesLR_ = vanesLR_swing;
-            break;
-        default:
-        case climate::CLIMATE_SWING_BOTH:
-            // vanes_ = vanes_swing;
-            vanesLR_ = vanesLR_swing;
-            vanes_ = vanes_swing;
-            break;
+        case climate::CLIMATE_SWING_VERTICAL: vanes_ = vanes_swing; break;
+        case climate::CLIMATE_SWING_HORIZONTAL: vanesLR_ = vanesLR_swing; break;
+        case climate::CLIMATE_SWING_BOTH: vanesLR_ = vanesLR_swing; vanes_ = vanes_swing; break;
+        default: break;
         }
-        this->platform_->set_vanesLR(vanesLR_); // Set vanesLR to swing
-        this->platform_->set_vanes(vanes_); // Set vanes to swing
+        this->platform_->set_vanesLR(vanesLR_);
+        this->platform_->set_vanes(vanes_);
     }
-
     this->publish_state();
 }
 
-
-/// Return the traits of this controller.
-#if ESPHOME_VERSION_CODE >= VERSION_CODE(2025, 11, 0)
 climate::ClimateTraits MhiClimate::traits() {
     auto traits = climate::ClimateTraits();
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
@@ -344,28 +195,11 @@ climate::ClimateTraits MhiClimate::traits() {
     traits.set_visual_min_temperature(this->minimum_temperature_);
     traits.set_visual_max_temperature(this->maximum_temperature_);
     traits.set_visual_temperature_step(this->temperature_step_);
-    // KORREKTUR: Überall climate:: hinzugefügt
+    [span_11](start_span)// KORREKTUR: Überall climate:: hinzugefügt[span_11](end_span)
     traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
     traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
     return traits;
 }
-#else
-climate::ClimateTraits MhiClimate::traits() {
-    auto traits = climate::ClimateTraits();
-    traits.set_supports_current_temperature(true);
-    traits.set_supported_modes({ climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT_COOL, climate::CLIMATE_MODE_COOL, climate::CLIMATE_MODE_HEAT, climate::CLIMATE_MODE_DRY, climate::CLIMATE_MODE_FAN_ONLY });
-    traits.set_supports_two_point_target_temperature(false);
-    traits.set_visual_min_temperature(this->minimum_temperature_);
-    traits.set_visual_max_temperature(this->maximum_temperature_);
-    traits.set_visual_temperature_step(this->temperature_step_);
-    // KORREKTUR: Überall climate:: hinzugefügt
-    traits.set_supported_fan_modes({ climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_QUIET, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH });
-    traits.set_supported_swing_modes({ climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_BOTH, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL });
-    return traits;
-}
-#endif
-
-
 
 } //namespace mhi
 } //namespace esphome

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -190,11 +190,24 @@ void MhiClimate::control(const climate::ClimateCall& call) {
             break;
         case climate::CLIMATE_MODE_COOL:
             mode_ = mode_cool;
-            this->platform_->set_vanes(vanes_1); // SMART LOGIC: Coanda (Oben)
+            this->platform_->set_vanes(vanes_1);  // SMART LOGIC: Coanda (Ganz Oben)
+            
+            // FIX: Verhindert, dass Home Assistant beim Moduswechsel ungewollt alte Zustände mitsendet
+            if (this->swing_mode != climate::CLIMATE_SWING_OFF) {
+                this->swing_mode = climate::CLIMATE_SWING_OFF;
+                this->publish_state();
+            }
             break;
+            
         case climate::CLIMATE_MODE_HEAT:
             mode_ = mode_heat;
-            this->platform_->set_vanes(vanes_5); // SMART LOGIC: Konvektion (Unten)
+            this->platform_->set_vanes(vanes_5);  // SMART LOGIC: Konvektion (Ganz Unten)
+            
+            // FIX: Verhindert, dass Home Assistant beim Moduswechsel ungewollt alte Zustände mitsendet
+            if (this->swing_mode != climate::CLIMATE_SWING_OFF) {
+                this->swing_mode = climate::CLIMATE_SWING_OFF;
+                this->publish_state();
+            }
             break;
         case climate::CLIMATE_MODE_DRY:
             mode_ = mode_dry;

--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -7,6 +7,29 @@ namespace mhi {
 
 static const char* TAG = "mhi.climate";
 
+static const char *climate_mode_name(climate::ClimateMode mode) {
+    switch (mode) {
+    case climate::CLIMATE_MODE_OFF: return "OFF";
+    case climate::CLIMATE_MODE_HEAT_COOL: return "HEAT_COOL";
+    case climate::CLIMATE_MODE_COOL: return "COOL";
+    case climate::CLIMATE_MODE_HEAT: return "HEAT";
+    case climate::CLIMATE_MODE_DRY: return "DRY";
+    case climate::CLIMATE_MODE_FAN_ONLY: return "FAN_ONLY";
+    default: return "UNKNOWN";
+    }
+}
+
+static const char *mhi_mode_name(int mode) {
+    switch (mode) {
+    case mode_auto: return "AUTO/HEAT_COOL";
+    case mode_dry: return "DRY";
+    case mode_cool: return "COOL";
+    case mode_fan: return "FAN_ONLY";
+    case mode_heat: return "HEAT";
+    default: return "UNKNOWN";
+    }
+}
+
 void MhiClimate::setup() {
     this->power_ = power_off;
     this->current_temperature = NAN;
@@ -44,6 +67,8 @@ void MhiClimate::update_status(ACStatus status, int value) {
 
     switch (status) {
     case status_power:
+        ESP_LOGI(TAG, "MHI bus status: power=%s. This is a status reported by the indoor unit; the originating controller is not present on the MHI bus.",
+                 value == power_on ? "ON" : "OFF");
         if (value == power_on) {
             this->power_ = power_on;
             update_status(status_mode, mode_tmp);
@@ -54,6 +79,7 @@ void MhiClimate::update_status(ACStatus status, int value) {
         }
         break;
     case status_mode:
+        ESP_LOGI(TAG, "MHI bus status: mode=%s (%i)", mhi_mode_name(value), value);
         mode_tmp = value;
     case opdata_mode:
     case erropdata_mode:
@@ -165,6 +191,24 @@ void MhiClimate::update_status(ACStatus status, int value) {
 }
 
 void MhiClimate::control(const climate::ClimateCall& call) {
+    // ESPHome's ClimateCall does not include the Home Assistant context, user,
+    // automation or client device. Home Assistant's logbook must be used to
+    // identify that upstream origin. This log proves that a climate control
+    // call reached the ESPHome entity before a matching MHI bus status change.
+    ESP_LOGI(TAG, "ESPHome climate control request received; upstream caller identity is unavailable on the device");
+    if (call.get_mode().has_value()) {
+        ESP_LOGI(TAG, "Control request: mode=%s", climate_mode_name(*call.get_mode()));
+    }
+    if (call.get_target_temperature().has_value()) {
+        ESP_LOGI(TAG, "Control request: target_temperature=%.1f C", *call.get_target_temperature());
+    }
+    if (call.get_fan_mode().has_value()) {
+        ESP_LOGI(TAG, "Control request: fan_mode=%i", static_cast<int>(*call.get_fan_mode()));
+    }
+    if (call.get_swing_mode().has_value()) {
+        ESP_LOGI(TAG, "Control request: swing_mode=%i", static_cast<int>(*call.get_swing_mode()));
+    }
+
     if (call.get_target_temperature().has_value()) {
         float target_temp = *call.get_target_temperature();
         this->target_temperature = target_temp; 

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -53,12 +53,9 @@ public:
     }
 
     // KORREKTUR für ESPHome 2026.3.0: 
-    // Diese leere Funktion verhindert den Abbruch des Updates.
+    [span_9](start_span)// Diese leere Funktion verhindert den Abbruch des Updates[span_9](end_span).
     void set_icon(const std::string &icon) {} 
 };
 
-
-
-
-
-
+}
+}

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -52,8 +52,7 @@ public:
         this->minimum_temperature_ = temp; 
     }
 
-    // KORREKTUR für ESPHome 2026.3.0: 
-    [span_9](start_span)// Diese leere Funktion verhindert den Abbruch des Updates[span_9](end_span).
+    // Diese leere Funktion verhindert den Abbruch des Updates
     void set_icon(const std::string &icon) {} 
 };
 

--- a/components/MhiAcCtrl/climate/mhi_climate.h
+++ b/components/MhiAcCtrl/climate/mhi_climate.h
@@ -42,7 +42,7 @@ private:
     int vanes_pos_old_state_;
     int vanes_pos_state_;
     MhiPlatform* platform_;
-
+    
 public:
     void set_temperature_offset_enabled(bool enabled) { 
         this->temperature_offset_enabled_ = enabled; 
@@ -51,7 +51,14 @@ public:
     void set_minimum_temperature(float temp) { 
         this->minimum_temperature_ = temp; 
     }
+
+    // KORREKTUR für ESPHome 2026.3.0: 
+    // Diese leere Funktion verhindert den Abbruch des Updates.
+    void set_icon(const std::string &icon) {} 
 };
 
-}
-}
+
+
+
+
+

--- a/components/MhiAcCtrl/mhi_platform.cpp
+++ b/components/MhiAcCtrl/mhi_platform.cpp
@@ -79,6 +79,25 @@ void MhiPlatform::dump_config() {
 void MhiPlatform:: cbiStatusFunction(ACStatus status, int value) {
     ESP_LOGD(TAG, "received status=%i value=%i", status, value);
 
+    constexpr unsigned long COMMAND_CORRELATION_WINDOW_MS = 10000;
+    if (status == status_power) {
+        const bool recent = this->power_command_seen_ &&
+                            millis() - this->last_power_command_ms_ <= COMMAND_CORRELATION_WINDOW_MS;
+        const bool matches = recent && value == this->last_power_command_;
+        ESP_LOGI(TAG, "power status origin hint: %s, reported=%i, last_command=%i, age_ms=%lu",
+                 matches ? "recent_local_command" : "no_matching_recent_local_command",
+                 value, this->last_power_command_,
+                 this->power_command_seen_ ? millis() - this->last_power_command_ms_ : 0UL);
+    } else if (status == status_mode) {
+        const bool recent = this->mode_command_seen_ &&
+                            millis() - this->last_mode_command_ms_ <= COMMAND_CORRELATION_WINDOW_MS;
+        const bool matches = recent && value == this->last_mode_command_;
+        ESP_LOGI(TAG, "mode status origin hint: %s, reported=%i, last_command=%i, age_ms=%lu",
+                 matches ? "recent_local_command" : "no_matching_recent_local_command",
+                 value, this->last_mode_command_,
+                 this->mode_command_seen_ ? millis() - this->last_mode_command_ms_ : 0UL);
+    }
+
     for (MhiStatusListener* listener:this->listeners_) {
         listener->update_status(status, value);
     }
@@ -100,13 +119,23 @@ float MhiPlatform::get_room_temp_offset() {
 
 void MhiPlatform::transfer_room_temperature(float value) {
     if (isnan(value)) {
+        if (!this->external_temperature_state_known_ || this->external_temperature_available_) {
+            ESP_LOGW(TAG, "external room temperature unavailable (NaN); falling back to the indoor-unit sensor");
+        }
+        this->external_temperature_state_known_ = true;
+        this->external_temperature_available_ = false;
         if (!isnan(this->last_room_temperature_)) {
-            ESP_LOGD(TAG, "set room_temp_api: value is NaN, using internal sensor");
             mhi_ac_ctrl_core_.set_troom(0xff); // reset target, use internal sensor
             this->last_room_temperature_ = NAN; // reset last room temperature
         }
         return;
     }
+
+    if (!this->external_temperature_state_known_ || !this->external_temperature_available_) {
+        ESP_LOGI(TAG, "external room temperature available again: %.2f C", value);
+    }
+    this->external_temperature_state_known_ = true;
+    this->external_temperature_available_ = true;
 
     if (this->temperature_offset_ > 0.0f) {  // if we have a offset value add this before setting troom value
         float orig_value = value;
@@ -129,12 +158,20 @@ void MhiPlatform::transfer_room_temperature(float value) {
 }
 
 void MhiPlatform::set_power(ACPower value) {
+    this->last_power_command_ = value;
+    this->last_power_command_ms_ = millis();
+    this->power_command_seen_ = true;
+    ESP_LOGI(TAG, "writing MHI command: power=%s", value == power_on ? "ON" : "OFF");
     this->mhi_ac_ctrl_core_.set_power(value);
 }
 void MhiPlatform::set_fan(int value) {
     this->mhi_ac_ctrl_core_.set_fan(value);
 }
 void MhiPlatform::set_mode(ACMode value){
+    this->last_mode_command_ = value;
+    this->last_mode_command_ms_ = millis();
+    this->mode_command_seen_ = true;
+    ESP_LOGI(TAG, "writing MHI command: mode=%i", value);
     this->mhi_ac_ctrl_core_.set_mode(value);
 }
 void MhiPlatform::set_tsetpoint(float value) {

--- a/components/MhiAcCtrl/mhi_platform.h
+++ b/components/MhiAcCtrl/mhi_platform.h
@@ -48,6 +48,15 @@ private:
     void transfer_room_temperature(float value);
     float last_room_temperature_ = NAN; 
     float temperature_offset_ = 0.0f;
+    bool external_temperature_state_known_ = false;
+    bool external_temperature_available_ = false;
+
+    unsigned long last_power_command_ms_ = 0;
+    unsigned long last_mode_command_ms_ = 0;
+    ACPower last_power_command_ = power_off;
+    ACMode last_mode_command_ = mode_auto;
+    bool power_command_seen_ = false;
+    bool mode_command_seen_ = false;
 
     int frame_size_;
     unsigned long room_temp_api_timeout_start_ = millis();

--- a/components/MhiAcCtrl/select/__init__.py
+++ b/components/MhiAcCtrl/select/__init__.py
@@ -5,15 +5,18 @@ from .. import MhiAcCtrl, CONF_MHI_AC_CTRL_ID
 
 CONF_VERTICAL = "vertical_vanes"
 CONF_VERTICAL_SELECTS = [
+    "Stop",
     "Up",
     "Up/Center",
+    "Mid",
     "Center/Down",
     "Down",
-    "Swing",
+    "Swing",    
 ]
 ICON_UP_DOWN = "mdi:arrow-up-down"
 CONF_HORIZONTAL = "horizontal_vanes"
 CONF_HORIZONTAL_SELECTS = [
+    "Stop",
     "Left",
     "Left/Center",
     "Center",

--- a/components/MhiAcCtrl/select/mhi_horizontal_vanes_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_horizontal_vanes_select.cpp
@@ -17,26 +17,26 @@ void MhiHorizontalVanesSelect::dump_config(){
 
 void MhiHorizontalVanesSelect::control(const std::string &value) {
     auto idx = this->index_of(value);
-    if (idx.has_value() && idx.value() < 8) {
-        
-        this->parent_->set_vanesLR(idx.value() + 1);
+    // Erhöht auf < 9, da du jetzt 9 Optionen hast (0 bis 8)
+    if (idx.has_value() && idx.value() < 9) {
+        // Die "+ 1" Rechnung ist weg! Index 0 (Stop) sendet jetzt auch direkt die 0.
+        this->parent_->set_vanesLR(idx.value());
     }
     this->publish_state(value);
 }
 
 void MhiHorizontalVanesSelect::update_status(ACStatus status, int value) {
-
     if (status == status_vanesLR) {
-        optional<std::string> opt = this->at(value - 1);
+        // Die "- 1" Rechnung ist weg! Empfängt der ESP die 0, wählt er auch Index 0 in der App.
+        optional<std::string> opt = this->at(value);
         if (opt.has_value()) {
             this->publish_state(opt.value());
             ESP_LOGD(TAG, "Vanes status updated");
         } else {
             ESP_LOGW(TAG, "Failed to map vanes status, value %i", value);
         }
-
     }
 }
 
 }  // namespace mhi
-}  // name
+}  // namespace esphome

--- a/components/MhiAcCtrl/select/mhi_vertical_vanes_select.cpp
+++ b/components/MhiAcCtrl/select/mhi_vertical_vanes_select.cpp
@@ -17,25 +17,26 @@ void MhiVerticalVanesSelect::dump_config(){
 
 void MhiVerticalVanesSelect::control(const std::string &value) {
     auto idx = this->index_of(value);
-    if (idx.has_value() && idx.value() < 5) {
-        this->parent_->set_vanes(idx.value() + 1);
+    // Limit auf < 7 erhöht, da wir jetzt 7 Optionen haben (Index 0 bis 6)
+    if (idx.has_value() && idx.value() < 7) {
+        // Das "+ 1" wurde entfernt. Index 0 (Stop) sendet jetzt auch den Befehl 0.
+        this->parent_->set_vanes(idx.value());
     }
     this->publish_state(value);
 }
 
 void MhiVerticalVanesSelect::update_status(ACStatus status, int value) {
-
     if (status == status_vanes) {
-        optional<std::string> opt = this->at(value - 1);
+        // Das "- 1" wurde entfernt. Wenn die Anlage Status 0 meldet, wird auch Index 0 (Stop) ausgewählt.
+        optional<std::string> opt = this->at(value);
         if (opt.has_value()) {
             this->publish_state(opt.value());
             ESP_LOGD(TAG, "Vanes status updated");
         } else {
             ESP_LOGW(TAG, "Failed to map vanes status, value %i", value);
         }
-
     }
 }
 
 }  // namespace mhi
-}  // name
+}  // namespace esphome

--- a/tests/fixtures/.gitignore
+++ b/tests/fixtures/.gitignore
@@ -1,0 +1,5 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml

--- a/tests/fixtures/mhi-srk25zsxw-d1-mini-2026.4.5.yaml
+++ b/tests/fixtures/mhi-srk25zsxw-d1-mini-2026.4.5.yaml
@@ -1,0 +1,278 @@
+# Sanitized compile fixture based on a real D1 mini / SRK25ZSX-W setup.
+# This intentionally uses the local checkout as external component source so CI
+# validates the current branch against ESPHome 2026.4.5.
+esphome:
+  name: mhi-srk25zsxw
+  friendly_name: "Klimaanlage OG01 Schlafzimmer"
+  min_version: 2026.4.5
+  platformio_options:
+    board_build.f_cpu: 160000000L
+    build_flags:
+      - -D USE_HW_SPI
+
+substitutions:
+  devicename: mhi-srk25zsxw
+
+esp8266:
+  board: d1_mini
+  framework:
+    version: recommended
+
+logger:
+  level: WARN
+  baud_rate: 0
+
+ota:
+  - platform: esphome
+    password: "test-ota-password"
+
+wifi:
+  ssid: "test-ssid"
+  password: "test-password"
+  min_auth_mode: WPA2
+  power_save_mode: none
+  ap:
+    ssid: "MHI-SRK25 Fallback"
+    password: "test-fallback-password"
+
+captive_portal:
+
+external_components:
+  - source:
+      type: local
+      path: ../../components
+    components: [MhiAcCtrl]
+
+api:
+  encryption:
+    # Dummy 32-byte key for compile tests only. Do not use in production.
+    key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  reboot_timeout: 0s
+  services:
+    - service: set_external_room_temperature
+      variables:
+        temperature_value: float
+      then:
+        - climate.mhi.set_external_room_temperature:
+            temperature: !lambda "return temperature_value;"
+
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+MhiAcCtrl:
+  id: mhi_ac_ctrl
+  frame_size: 33
+  sck_pin: 14
+  mosi_pin: 13
+  miso_pin: 12
+  initial_vertical_vanes_position: 5
+  initial_horizontal_vanes_position: 8
+  room_temp_timeout: 60
+  external_temperature_sensor: room_temperature_sensor
+
+button:
+  - platform: restart
+    name: "Neustart"
+    entity_category: diagnostic
+
+climate:
+  - platform: MhiAcCtrl
+    name: "Klimaanlage OG01 Schlafzimmer"
+    id: mhi_ac
+    temperature_offset: false
+    visual:
+      min_temperature: 15
+      temperature_step:
+        target_temperature: 0.5
+        current_temperature: 0.1
+    on_control:
+      - logger.log: "Steuerbefehl empfangen; Leistung zurückgesetzt!"
+      - sensor.template.publish:
+          id: power
+          state: 0
+
+binary_sensor:
+  - platform: MhiAcCtrl
+    defrost:
+      name: "Abtauvorgang"
+    vanes_3d_auto_enabled:
+      name: "3D-Auto aktiviert"
+
+number:
+  - platform: template
+    name: "Netzspannung"
+    id: grid_voltage
+    unit_of_measurement: "V"
+    optimistic: true
+    min_value: 220
+    max_value: 240
+    step: 0.1
+    initial_value: 230
+
+sensor:
+  - platform: homeassistant
+    id: room_temperature_sensor
+    entity_id: sensor.klimasensor_schlafzimmer_temperature
+    filters:
+      - heartbeat: 30s
+
+  - platform: uptime
+    name: "Betriebszeit"
+
+  - platform: wifi_signal
+    name: "WLAN-Signal"
+    update_interval: 30s
+
+  - platform: MhiAcCtrl
+    outdoor_temperature:
+      name: "Außentemperatur"
+    return_air_temperature:
+      name: "Rücklufttemperatur"
+    outdoor_unit_fan_speed:
+      name: "Außengerät Lüftergeschwindigkeit"
+    indoor_unit_fan_speed:
+      name: "Innengerät Lüftergeschwindigkeit"
+    compressor_frequency:
+      name: "Verdichterfrequenz"
+    indoor_unit_total_run_time:
+      name: "Innengerät Laufzeit (gesamt)"
+    compressor_total_run_time:
+      name: "Kompressorlaufzeit (gesamt)"
+    current_power:
+      name: "Stromaufnahme"
+      id: ac_current_power
+      on_value:
+        then:
+          - sensor.template.publish:
+              id: power
+              state: !lambda "return id(ac_current_power).state * id(grid_voltage).state;"
+    energy_used:
+      name: "Energieverbrauch"
+    vanes_pos:
+      name: "Lamellenstellung"
+    vanesLR_pos:
+      name: "Lamellen Links⁄Rechts"
+
+  - platform: template
+    id: power
+    name: "Aktuelle Leistung"
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    icon: mdi:lightning-bolt
+
+  - platform: total_daily_energy
+    name: "Tagesenergie (gesamt)"
+    power_id: power
+    unit_of_measurement: kWh
+    method: left
+    filters:
+      - multiply: 0.001
+      - throttle: 300s
+    icon: mdi:lightning-bolt
+
+  - platform: template
+    id: power_heat
+    name: "Leistung (Heizen)"
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    lambda: |-
+      if (id(mhi_ac).mode == climate::CLIMATE_MODE_HEAT) return id(power).state;
+      return 0.0;
+
+  - platform: template
+    id: power_cool
+    name: "Leistung (Kühlen)"
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    lambda: |-
+      if (id(mhi_ac).mode == climate::CLIMATE_MODE_COOL) return id(power).state;
+      return 0.0;
+
+  - platform: template
+    id: power_fan
+    name: "Leistung (Nur Lüften)"
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    lambda: |-
+      if (id(mhi_ac).mode == climate::CLIMATE_MODE_FAN_ONLY) return id(power).state;
+      return 0.0;
+
+  - platform: template
+    id: power_dry
+    name: "Leistung (Entfeuchten)"
+    unit_of_measurement: W
+    device_class: power
+    state_class: measurement
+    lambda: |-
+      if (id(mhi_ac).mode == climate::CLIMATE_MODE_DRY) return id(power).state;
+      return 0.0;
+
+  - platform: total_daily_energy
+    name: "Tagesenergie (Heizen)"
+    power_id: power_heat
+    unit_of_measurement: kWh
+    method: left
+    filters:
+      - multiply: 0.001
+      - throttle: 300s
+    icon: mdi:fire
+
+  - platform: total_daily_energy
+    name: "Tagesenergie (Kühlen)"
+    power_id: power_cool
+    unit_of_measurement: kWh
+    method: left
+    filters:
+      - multiply: 0.001
+      - throttle: 300s
+    icon: mdi:snowflake
+
+  - platform: total_daily_energy
+    name: "Tagesenergie (Nur Lüften)"
+    power_id: power_fan
+    unit_of_measurement: kWh
+    method: left
+    filters:
+      - multiply: 0.001
+      - throttle: 300s
+    icon: mdi:fan
+
+  - platform: total_daily_energy
+    name: "Tagesenergie (Entfeuchten)"
+    power_id: power_dry
+    unit_of_measurement: kWh
+    method: left
+    filters:
+      - multiply: 0.001
+      - throttle: 300s
+    icon: mdi:water-percent
+
+text_sensor:
+  - platform: version
+    name: "ESPHome-Version"
+  - platform: wifi_info
+    ip_address:
+      name: "IP-Adresse"
+  - platform: MhiAcCtrl
+    protection_state:
+      name: "Verdichter-Schutzstatus"
+
+select:
+  - platform: MhiAcCtrl
+    vertical_vanes:
+      name: "Lamellensteuerung Hoch-Runter"
+      id: vertical_vanes
+    horizontal_vanes:
+      name: "Lamellensteuerung Links-Rechts"
+    fan_speed:
+      name: "Lüftergeschwindigkeit"
+
+switch:
+  - platform: MhiAcCtrl
+    vanes_3d_auto:
+      name: "3D-Auto"

--- a/tests/fixtures/mhi-srk25zsxw-d1-mini-2026.4.5.yaml
+++ b/tests/fixtures/mhi-srk25zsxw-d1-mini-2026.4.5.yaml
@@ -19,7 +19,14 @@ esp8266:
     version: recommended
 
 logger:
-  level: WARN
+  # Compile INFO messages, but keep unrelated components at WARN.
+  # The two MHI tags distinguish incoming ESPHome control calls from
+  # status changes reported by the indoor unit on the MHI bus.
+  level: INFO
+  initial_level: WARN
+  logs:
+    mhi.climate: INFO
+    mhi.platform: INFO
   baud_rate: 0
 
 ota:
@@ -87,7 +94,6 @@ climate:
         target_temperature: 0.5
         current_temperature: 0.1
     on_control:
-      - logger.log: "Steuerbefehl empfangen; Leistung zurückgesetzt!"
       - sensor.template.publish:
           id: power
           state: 0


### PR DESCRIPTION
Hi @ginkage,

I've updated the component to ensure full compatibility with ESPHome 2026.3.0. Here is a summary of the changes:

### Compatibility Fixes:
* *__init__.py*: Added synchronous=False to all registered actions to comply with new ESPHome requirements and remove log warnings.
* *mhi_climate.h*: Implemented a dummy set_icon function. ESPHome 2026.3.0 tries to call this due to RAM optimizations for climate components; without it, the build fails with: error: 'class esphome::mhi::MhiClimate' has no member named 'set_icon'.
* *mhi_climate.cpp*: Fixed missing climate:: namespaces in the traits() function for fan modes.

### New Features:
* *Smart Vane Logic*: Integrated automatic vane positioning based on the current mode:
  * *Heating*: Vanes move to position 5 (down) to improve convection.
  * *Cooling*: Vanes move to position 1 (up) to utilize the Coanda effect for better air distribution.
  * This logic works for both API calls and status updates (e.g., when using the original IR remote).

Thanks for this great project!