### PR TITLE
ESP8266: direct GPIO registers for SPI bit-bang (fix loop error -2 and -1 on recent ESPHome)

### DIFF
--- a/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
+++ b/components/MhiAcCtrl/MHI-AC-Ctrl-core.cpp
@@ -236,22 +236,32 @@ static byte MOSI_frame[33];
   //Serial.println();
   //Serial.print(F("MISO:"));
   // read/write MOSI/MISO frame
-  for (uint8_t byte_cnt = 0; byte_cnt < frameSize; byte_cnt++) { // read and write a data packet of 20 bytes
-    //Serial.printf("x%02x ", MISO_frame[byte_cnt]);
+  // On ESP8266, digitalRead/Write are ~half an SPI clock period too slow and tip
+  // timing-marginal units past the error threshold (issue #191) — drive/read the
+  // pins through direct GPIO registers instead. GPIO0..15 only (D1-mini wiring);
+  // ESP32 keeps digitalRead/Write unchanged.
+#ifdef ESP8266
+  const uint32_t sck_mask = (1UL << SCK_PIN), mosi_mask = (1UL << MOSI_PIN), miso_mask = (1UL << MISO_PIN);
+  #define MHI_SCK_HIGH      (GPI & sck_mask)
+  #define MHI_MOSI_HIGH     (GPI & mosi_mask)
+  #define MHI_MISO_WRITE(v) do { if (v) GPOS = miso_mask; else GPOC = miso_mask; } while (0)
+#else
+  #define MHI_SCK_HIGH      digitalRead(SCK_PIN)
+  #define MHI_MOSI_HIGH     digitalRead(MOSI_PIN)
+  #define MHI_MISO_WRITE(v) digitalWrite(MISO_PIN, (v))
+#endif
+  for (uint8_t byte_cnt = 0; byte_cnt < frameSize; byte_cnt++) { // read and write a data packet
     MOSI_byte = 0;
     byte bit_mask = 1;
     for (uint8_t bit_cnt = 0; bit_cnt < 8; bit_cnt++) { // read and write 1 byte
-      SCKMillis = millis();
-      while (digitalRead(SCK_PIN)) { // wait for falling edge
-        if (millis() - startMillis > max_time_ms)
+      uint16_t guard = 0;
+      while (MHI_SCK_HIGH) { // wait for falling edge (millis() kept out of the spin)
+        if (++guard == 0 && millis() - startMillis > max_time_ms)
           return err_msg_timeout_SCK_high;       // SCK stuck@ high error detection
-      } 
-      if ((MISO_frame[byte_cnt] & bit_mask) > 0)
-        digitalWrite(MISO_PIN, 1);
-      else
-        digitalWrite(MISO_PIN, 0);
-      while (!digitalRead(SCK_PIN)) {} // wait for rising edge
-      if (digitalRead(MOSI_PIN))
+      }
+      MHI_MISO_WRITE((MISO_frame[byte_cnt] & bit_mask) > 0);
+      while (!MHI_SCK_HIGH) {} // wait for rising edge
+      if (MHI_MOSI_HIGH)
         MOSI_byte += bit_mask;
       bit_mask = bit_mask << 1;
     }
@@ -260,6 +270,9 @@ static byte MOSI_frame[33];
       MOSI_frame[byte_cnt] = MOSI_byte;
     }
   }
+#undef MHI_SCK_HIGH
+#undef MHI_MOSI_HIGH
+#undef MHI_MISO_WRITE
 
   checksum = calc_checksum(MOSI_frame);
   if (((MOSI_frame[SB0] & 0xfe) != 0x6c) | (MOSI_frame[SB1] != 0x80) | (MOSI_frame[SB2] != 0x04))


### PR DESCRIPTION
## Problem

On recent ESPHome (2026.4+), ESP8266 builds spam the log with

[E][mhi.platform]: mhi_ac_ctrl_core,loop error: -1
[E][mhi.platform]: mhi_ac_ctrl_core,loop error: -2

(`-1` = invalid signature, `-2` = invalid checksum). On timing-marginal units the climate entity then stops responding in Home Assistant entirely, because the core's ~120 s "no valid frame" safety shutoff trips.

Most affected are the legacy `frame_size: 20` units (SRK/SRF-style indoor units), and the symptoms persist even with `board_build.f_cpu: 160000000L` (160 MHz) already set.

## Root cause

The SCK/MOSI/MISO lines are bit-banged in software in `MHI_AC_Ctrl_Core::loop()` using `digitalRead()` / `digitalWrite()`. On ESP8266 each of those goes through the Arduino HAL and costs on the order of a microsecon a large fraction of an MHI SPI half-clock. ESPHome 2026.4 reworked the main loop (more per-tick overhead), and combined with ESP8266 the wrong bits, and the assembled frame fails its signature/checksum check.

## Fix

Replace the three per-bit pin operations in the hot loop with **direct GPIO register access on ESP8266** — read via `GPI`, drive via `GPOS` / `GPOC` (W1TS/W1TC) — which is a couple of instructions instead of a HAL call and restores the timing margin. `millis()` is also kept out of the falling-edge wait (checked only if SCK is genuinely stuck) so edge-detection latency stays minimal.

It's done with three small macros, so there's still a **single loop body** (no duplication): on ESP8266 they expand to register access, and on every other platform they fall back to `digitalRead`/`digitalWrite` via `#else`, so **ESP32 behaviour is unchanged**. So if someone with an ESP32 wants to test this, the extra condition could be taken out.

## Scope / notes

- **ESP8266 only**; ESP32 path is untouched. --> someone with that hardware needs to verify this fix.
- **Frame-size agnostic** — works for both `20` and `33`.
- The register approach assumes SCK/MOSI/MISO are on **GPIO0–15** (the `GPI`/`GPOS`/`GPOC` registers only cover those). True for the standard D1-mini wiring (SCK 14, MOSI 13, MISO 12); GPIO16 would need separate handling. Noted in a code comment.
- Pin masks are precomputed once per `loop()` (pin numbers are runtime-configurable), keeping the shift out of the inner loop.

## Testing

Tested on **4 live MHI indoor units** — 2× wall (`frame_size: 33`) and 2× floor (`frame_size: 20`), all D1-mini on ESPHome 2026.6.x. All four are stable and responsive in Home Assistant; the previously constant `-1`/`-2` errors and the HA shutoff on the floor units are gone.

Refs #191.

Disclaimer: I used AI for it.