### PR TITLE
Fix LR vane state update order before publishing

### DIFF
--- a/components/MhiAcCtrl/climate/mhi_climate.cpp
+++ b/components/MhiAcCtrl/climate/mhi_climate.cpp
@@ -191,8 +191,8 @@ void MhiClimate::update_status(ACStatus status, int value) {
             }
 
         }
-        this->publish_state();
         this->vanesLR_pos_state_ = value;
+        this->publish_state();
         break;
     case status_troom:
         // Calculate the temperature and apply the offset for 0.5°C steps


### PR DESCRIPTION
Update vanesLR_pos_state_ before calling publish_state().

Previously, the component published the climate state before storing the newly received left/right vane position. This could cause Home Assistant to receive a state calculated using the previous LR vane value, resulting in a temporary or incorrect swing state being reported.

The vertical vane handler already updates its internal state before publishing, so this change also makes the LR vane handling consistent with the vertical vane implementation.